### PR TITLE
Fix eight lifecycle and crash-recovery defects

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -42,11 +42,18 @@ call inside a worker.
 | `max_host_calls` | calls out through an import, per invocation |
 | `max_memory_pages` | every memory one instance can reach, imports included |
 | node page budget | linear memory across every instance |
+| `max_rec_groups` | distinct recursive type groups interned node-wide |
 
 `max_memory_pages` counts an imported memory, because a module that imports one
 can address every page of it, and it counts a memory once however many import
 slots name it. A memory two instances share grows only as far as the stricter
 of their ceilings allows.
+
+`max_rec_groups` bounds a table whose rows can never be removed: a type id is
+compared by `ref.eq` and by import matching, so dropping one would make two
+different types the same for whatever module still holds it. A module that would
+push the node past the limit is refused with `too_many_rec_groups`. The default
+is 100,000 and a real module declares tens.
 
 `fuel`, `max_depth` and `max_host_calls` belong to the invocation the embedder
 started, not to each entry into the interpreter. A guest that recurses by

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,16 +82,43 @@ the most tempting wrong claim available about this design. A process is a
    timeout, which the specification defines as waiting forever: it consumes no
    fuel and nothing here will interrupt it.
 
-5. **Timing and microarchitectural side channels are not addressed.** Nothing
+5. **A start function that traps keeps its instance.** The specification
+   requires it: the store keeps what instantiation wrote, so a module that
+   fills an imported memory and then traps has to leave those bytes behind.
+   The pages, tables and globals it took stay held. In a long-lived builder
+   that instantiates many modules, a hostile one can repeat this until the node
+   budget is gone.
+
+   The instance comes back in the error so you can end it when you know nothing
+   escaped:
+
+   ```erlang
+   case wasm:instantiate(Mod, Imports) of
+       {ok, Inst} ->
+           {ok, Inst};
+       {error, #{ctx := #{instance := Inst}} = Error} ->
+           ok = wasm:destroy(Inst),
+           {error, Error};
+       {error, Error} ->
+           {error, Error}
+   end.
+   ```
+
+   Do not destroy it if another instance imported something from this one and
+   may still reach what it wrote. Building each instantiation in its own
+   short-lived process is the other answer, and the one `docs/worker.md`
+   already recommends.
+
+6. **Timing and microarchitectural side channels are not addressed.** Nothing
    here stops a co-tenant module measuring shared cache behaviour. A shared BEAM
    node is not a boundary against that class of attack; only OS-level or
    hardware separation is.
 
-6. **An inline call cannot be interrupted.** `wasm:call/3` runs in your process.
+7. **An inline call cannot be interrupted.** `wasm:call/3` runs in your process.
    A module looping with `fuel => infinity` hangs you and cannot be killed
    without killing you. Use a worker for anything untrusted.
 
-7. **WASI path resolution has a residual race without the NIF.** On the
+8. **WASI path resolution has a residual race without the NIF.** On the
    `fallback` backend, a component can be swapped for a symlink between the
    check and the open. Check `wasi_fs:backend()`; on `fallback`, do not point a
    preopen at a directory a hostile party can write to concurrently.

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -220,13 +220,26 @@ run_start(#module{start = undefined}, Inst, _Opts) ->
 %% `foreign_reference' trap.
 %%
 %% So the instance stays, reachable through whatever it wrote, and what it
-%% holds is released when the process that built it exits. Nobody is handed the
-%% handle, so there is no earlier moment at which anything could release it.
+%% holds is released when the process that built it exits.
+%%
+%% It is *handed over* now, in the error's context under `instance`. It used to
+%% be dropped on the floor, and "the builder exits" is not a bound in a process
+%% that builds many: every trapping instantiation left its memories, tables and
+%% globals held for the life of that process, with no handle anywhere to release
+%% them through. A caller that knows nothing escaped can now `destroy/1` it, and
+%% one that does not can ignore the field and get exactly the old behaviour.
 run_start(#module{start = F}, Inst, Opts) ->
     case invoke(Inst, F, [], Opts) of
         {ok, _} -> {ok, Inst};
-        {error, _} = E -> E
+        {error, Err} -> {error, abandoned(Err, Inst)}
     end.
+
+%% Only where there is somewhere to put it. An error from a host function is
+%% whatever that function returned and is not this module's to reshape.
+abandoned(#{ctx := Ctx} = Err, Inst) when is_map(Ctx) ->
+    Err#{ctx := Ctx#{instance => Inst}};
+abandoned(Err, _Inst) ->
+    Err.
 
 %%% ----------------------------------------------------------------- calls ---
 

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -597,6 +597,12 @@ destroy(Inst) ->
                                                     wasm_global:is_global(G)],
               ok
           end),
+    %% The compiled code this instance may have claimed. Same argument as the
+    %% memories above: the lease names the instance, so it goes when the
+    %% instance does, and until this line it went only when the owning process
+    %% died. A process serving many distinct modules pinned the sixteen slots
+    %% one at a time and then interpreted for ever.
+    _ = wasm_error:capture(fun() -> wasm_jit:release(Inst) end),
     %% The object store goes when the last instance sharing it goes, not with
     %% the first: linked instances hold references into one store.
     ok = wasm_heap:delete(Inst#inst.heap, Inst#inst.id),

--- a/src/wasm_engine.erl
+++ b/src/wasm_engine.erl
@@ -35,6 +35,7 @@ eventually refuses every allocation on the node.
 -export([table_put/2, table_get/1, table_forget/1]).
 -export([cell_put/2, cell_get/1, cell_forget/1]).
 -export([intern_rec_group/1, ensure_store/0]).
+-export([rec_group_limit/0, rec_groups_in_use/0]).
 -export([ensure_waiters/0, ensure_waiter_table/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
@@ -51,6 +52,9 @@ eventually refuses every allocation on the node.
 
 %% 1 GiB of linear memory across the whole node unless configured otherwise.
 -define(DEFAULT_PAGE_LIMIT, 16384).
+%% Distinct recursive type groups this node will intern. A row is never removed
+%% (see `intern_rec_group/1'), so this is the whole bound on that table.
+-define(DEFAULT_REC_GROUP_LIMIT, 100000).
 
 %% The largest a table may become. Not a node-wide budget: it bounds the work
 %% one `table.grow' can be asked to do, since a table's declared maximum may be
@@ -180,6 +184,22 @@ new_counters() ->
 configured_limit() ->
     application:get_env(wasm, page_limit, ?DEFAULT_PAGE_LIMIT).
 
+-doc """
+How many distinct recursive type groups this node may intern.
+
+Set it with `application:set_env(wasm, max_rec_groups, N)`. The default is high
+enough that no legitimate workload reaches it: a real module declares tens of
+groups and the interning is shared, so this is a bound on churn from modules
+that keep arriving with types nothing has seen before.
+""".
+-spec rec_group_limit() -> pos_integer().
+rec_group_limit() ->
+    application:get_env(wasm, max_rec_groups, ?DEFAULT_REC_GROUP_LIMIT).
+
+-doc "How many are interned. Never goes down: see `intern_rec_group/1`.".
+-spec rec_groups_in_use() -> non_neg_integer().
+rec_groups_in_use() -> atomics:get(counters_ref(), ?SLOT_TYPE_IDS).
+
 %%% --------------------------------------------------------- table storage ---
 %%
 %% Table contents live here rather than inside an instance, because a table can
@@ -225,6 +245,24 @@ intern_rec_group(Key) ->
     case ets:lookup(?TABLES_TAB, {rec_group, Key}) of
         [{_, Id}] -> Id;
         [] ->
+            %% Bounded, because a row here is never removed and never can be: a
+            %% type id is compared by `ref.eq` and by import matching, so
+            %% dropping one would silently make two different types the same for
+            %% whatever module still holds it, and nothing here knows when the
+            %% last such module is gone. A `#module{}` is a plain term with no
+            %% lifetime to hang a reference count on.
+            %%
+            %% So the table grows for the life of the node, and a caller feeding
+            %% it distinct type groups grew it without bound while the module
+            %% cache beside it stayed bounded. This turns that into a limit that
+            %% refuses a module, which is what every other node-wide budget here
+            %% does: `wasm_engine:set_page_limit/1` for pages,
+            %% `max_resident_modules` for the cache.
+            rec_groups_in_use() < rec_group_limit()
+                orelse wasm_error:invalid(
+                         too_many_rec_groups,
+                         ~"the node's recursive type table is full",
+                         #{limit => rec_group_limit()}),
             Id = atomics:add_get(counters_ref(), ?SLOT_TYPE_IDS, 1),
             case ets:insert_new(?TABLES_TAB, {{rec_group, Key}, Id}) of
                 true -> Id;

--- a/src/wasm_heap.erl
+++ b/src/wasm_heap.erl
@@ -403,7 +403,20 @@ declaring no struct and no array type, so those pay one comparison.
 """.
 -spec lease(undefined | heap()) -> boolean().
 lease(undefined) -> false;
-lease({wasm_heap, Objs, _, Ctr}) -> read_lease(Objs, Ctr, 0), true.
+lease({wasm_heap, Objs, _, Ctr}) ->
+    read_lease(Objs, Ctr, 0),
+    %% Who is holding it, so that a reader killed before its `after` runs can be
+    %% told from one still working. The count alone cannot: a leaked increment
+    %% and a busy reader look identical, and the leaked one stopped `try_
+    %% exclusive/1` from ever matching again, which stopped collection for the
+    %% life of the store.
+    %%
+    %% One `ets:update_counter` per *outermost* invocation, and only for a
+    %% module that declares a struct or an array type: `lease/1` already answers
+    %% `false` for every other module, so nothing that does not use the object
+    %% store pays for this.
+    ok = remember_reader(Objs),
+    true.
 
 read_lease(Objs, Ctr, Tries) ->
     case atomics:add_get(Ctr, ?LEASE, 1) >= ?EXCL of
@@ -456,6 +469,17 @@ unmark_collector(Objs) ->
     try ets:delete(Objs, ?COLLECTOR) catch error:badarg -> true end,
     ok.
 
+%% Take the mark back only if it is still ours. A plain delete would take a
+%% concurrent collector's mark away with it, and that collector holds the store:
+%% readers would then find `?EXCL` with nobody marked, which is exactly the
+%% state marking first exists to make impossible.
+unmark_if_mine(Objs) ->
+    Me = self(),
+    try ets:select_delete(Objs, [{{?COLLECTOR, Me, '_'}, [], [true]}])
+    catch error:badarg -> 0
+    end,
+    ok.
+
 -doc """
 Give up a read lease.
 
@@ -466,20 +490,88 @@ gathering roots is not this module's business.
 -spec unlease(undefined | heap(), boolean()) -> ok | collect_now.
 unlease(_H, false) -> ok;
 unlease({wasm_heap, Objs, _, Ctr}, true) ->
+    ok = forget_reader(Objs),
     case atomics:sub_get(Ctr, ?LEASE, 1) of
         0 -> last_out(Objs, Ctr);
-        _ -> ok
+        N -> still_inside(Objs, Ctr, N)
     end.
+
+%% Somebody is still in, so this reader is not the one to collect. Unless the
+%% somebody is dead: a reader killed with `exit(Pid, kill)` never ran the
+%% `after` that gives its count back, and `last_out/2` would then never see
+%% zero again however long the store waited.
+%%
+%% Checked only when a collection is actually pending, so the ordinary path is
+%% the same two atomics it has always been, and only from the *falling* edge, so
+%% a store with steady traffic pays for it once per invocation that leaves
+%% somebody behind rather than once per invocation.
+still_inside(Objs, Ctr, N) ->
+    case atomics:get(Ctr, ?REQUEST) of
+        0 -> ok;
+        _ -> reap(Objs, Ctr, N)
+    end.
+
+%% Give back what dead readers are holding, and collect if that empties the
+%% store. `is_process_alive/1` is the authority here for the same reason
+%% `code:soft_purge/1` is the authority in `wasm_code_slots`: a lease is given
+%% back in an `after` and an `after` does not run for a killed process, so the
+%% lease cannot be what decides.
+reap(Objs, Ctr, N) ->
+    case dead_readers(Objs) of
+        0 -> ok;
+        Dead ->
+            case atomics:sub_get(Ctr, ?LEASE, min(Dead, N)) of
+                0 -> case last_out(Objs, Ctr) of
+                         collect_now -> collect_now;
+                         ok -> ok
+                     end;
+                _ -> ok
+            end
+    end.
+
+%% Rows are deleted as they are counted, so two reapers cannot both subtract
+%% for the same corpse: `ets:take/2` hands the row to exactly one of them.
+dead_readers(Objs) ->
+    try ets:select(Objs, [{{{reader, '$1'}, '_'}, [], ['$1']}]) of
+        Pids ->
+            lists:sum([Held || Pid <- Pids, not is_process_alive(Pid),
+                               Held <- [taken(Objs, Pid)]])
+    catch error:badarg -> 0
+    end.
+
+taken(Objs, Pid) ->
+    case ets:take(Objs, {reader, Pid}) of
+        [{_, Held}] -> Held;
+        [] -> 0
+    end.
+
+remember_reader(Objs) ->
+    Key = {reader, self()},
+    try ets:update_counter(Objs, Key, {2, 1}, {Key, 0}) catch error:badarg -> 0 end,
+    ok.
+
+forget_reader(Objs) ->
+    Key = {reader, self()},
+    try
+        case ets:update_counter(Objs, Key, {2, -1}, {Key, 0}) of
+            N when N =< 0 -> ets:delete(Objs, Key);
+            _ -> true
+        end
+    catch error:badarg -> true
+    end,
+    ok.
 
 last_out(Objs, Ctr) ->
     case atomics:get(Ctr, ?REQUEST) of
         0 -> ok;
         _ ->
+            %% Marked first, for the reason `try_exclusive/1` gives.
+            ok = mark_collector(Objs, 0),
             case atomics:compare_exchange(Ctr, ?LEASE, 0, ?EXCL) of
-                ok -> ok = mark_collector(Objs, 0), collect_now;
+                ok -> collect_now;
                 %% Somebody came back in first. The request stands and the next
                 %% one out will find it.
-                _ -> ok
+                _ -> ok = unmark_if_mine(Objs), ok
             end
     end.
 
@@ -492,9 +584,18 @@ upgrade that cannot deadlock: there is nobody to wait for.
 -spec try_exclusive(undefined | heap()) -> boolean().
 try_exclusive(undefined) -> false;
 try_exclusive({wasm_heap, Objs, _, Ctr}) ->
+    %% Marked *before* the exchange, and this order is the whole safety of it.
+    %% The other way round left a window where the store read as exclusive with
+    %% no collector row: a process killed in there stranded `?EXCL` for ever,
+    %% `reclaim/2` found `none` and answered `false`, and every reader spun in
+    %% `read_lease/3` without bound. This way that state cannot exist, and the
+    %% state this order does allow -- marked, not exclusive -- is harmless,
+    %% because the row is only ever consulted once the count is already at
+    %% `?EXCL`.
+    ok = mark_collector(Objs, 1),
     case atomics:compare_exchange(Ctr, ?LEASE, 1, ?EXCL + 1) of
-        ok -> ok = mark_collector(Objs, 1), true;
-        _ -> false
+        ok -> true;
+        _ -> ok = unmark_if_mine(Objs), false
     end.
 
 -doc "Release the exclusive hold, leaving any read lease the caller had.".
@@ -552,8 +653,14 @@ collect({wasm_heap, _, Elems, Ctr} = H, Roots) ->
         true -> major(H, Roots, Next);
         false -> minor(H, Roots, Next)
     end,
-    forget_all(Elems),
+    %% The watermark first, then the remembered set. A collector killed between
+    %% the two used to drop the remembered set while the watermark still named
+    %% the previous generation, so the next minor collection traced neither the
+    %% old-to-young references nor the objects they pointed at, and freed live
+    %% ones. This order leaves the conservative state instead: a remembered set
+    %% larger than it needs to be, which costs a longer trace and nothing else.
     atomics:put(Ctr, ?WATERMARK, Next),
+    forget_all(Elems),
     ok.
 
 -doc "Whether the next collection will trace the whole store.".
@@ -807,7 +914,11 @@ sweep_from('$end_of_table', _Objs, _Elems, _Marks) -> ok;
 %% they are not objects and have no mark bit. The collector row is always
 %% present during a sweep, because taking the store exclusively is what writes
 %% it and what a sweep runs under.
-sweep_from(Key, Objs, Elems, Marks) when Key =:= ?REGISTRY; Key =:= ?COLLECTOR ->
+%% An object id is an integer, so anything else in this table is bookkeeping:
+%% the registry, the collector, and the reader rows. Written as the shape of a
+%% key rather than as a list of them, because the list had to be extended every
+%% time a row was added and forgetting would have deleted live objects.
+sweep_from(Key, Objs, Elems, Marks) when not is_integer(Key) ->
     sweep_from(ets:next(Objs, Key), Objs, Elems, Marks);
 sweep_from(Id, Objs, Elems, Marks) ->
     Next = ets:next(Objs, Id),

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -53,7 +53,7 @@ why it is affordable there and nowhere else.
 moved, because even with all three a refusal still interprets.
 """.
 
--export([entry/3, after_call/2, counts/0, reset_counts/0, await/2]).
+-export([entry/3, after_call/2, counts/0, reset_counts/0, await/2, release/1]).
 -export([reentered/0]).
 -export([compiler_loop/0]).
 -export([dump/1, dump/2]).
@@ -177,6 +177,24 @@ maybe_adopt(Inst, Limits, Entry) ->
                 error -> put(?ASK, true), Entry
             end
     end.
+
+-doc """
+Give back the slot lease this instance took, if it took one.
+
+Called from `wasm:destroy/1` beside the memory, table and global releases, and
+for the same reason: the lease names the *instance*, so it has to go when the
+instance does. Until this existed it went only when the owning process died,
+and a long-lived process serving many distinct modules pinned the slots one at
+a time until the pool was gone and every later module interpreted for the life
+of the node. `wasm_code_slots`'s moduledoc describes exactly this shape as the
+usage it expects and nothing called it.
+
+Idempotent, because `destroy/1` is: releasing a lease that is not there is a
+no-op in `wasm_code_slots:drop/3`, which is the same property that makes a
+double release of a memory harmless.
+""".
+-spec release(#inst{}) -> ok.
+release(Inst) -> wasm_code_slots:release(key(Inst), {instance, Inst#inst.id}).
 
 -doc "How much has been compiled, and how often generated code was entered.".
 -spec counts() -> #{atom() => non_neg_integer()}.

--- a/src/wasm_keeper.erl
+++ b/src/wasm_keeper.erl
@@ -226,11 +226,22 @@ last looked. Concurrent growers queue here rather than being refused.
 grow_begin(Resource, Delta, Ceiling) ->
     call({grow_begin, Resource, Delta, Ceiling}).
 
--doc "Publish the chunk tuple and the new size together, ending the growth.".
--spec grow_commit(resource(), reference(), tuple(), non_neg_integer()) -> ok.
+-doc """
+Publish the chunk tuple and the new size together, ending the growth.
+
+`stale` when the keeper has no record of this growth, which a restart between
+`grow_begin/3` and here produces: it rolled the reservation back, so publishing
+now would put a size into the store that nothing is charged for. The caller
+gives up and the guest sees -1.
+""".
+-spec grow_commit(resource(), reference(), tuple(), non_neg_integer()) ->
+          ok | stale.
 grow_commit(Resource, GrowRef, Chunks, NewPages) ->
     case call({grow_commit, Resource, GrowRef, Chunks, NewPages}) of
         ok -> ok;
+        stale -> stale;
+        %% No keeper at all is not the same as a keeper that disowned this
+        %% growth: nothing rolled anything back, so the local extension stands.
         {error, keeper_unavailable} -> ok
     end.
 
@@ -340,8 +351,16 @@ init([]) ->
     %% are rebuilt from them. Without this the registry would survive and its
     %% death-release would not, which is the worse of the two halves to keep.
     {Held, Mons} = adopt(),
-    {ok, #{held => Held, mons => Mons, growing => #{}, queued => #{},
-           caps => #{}, totals => adopt_totals()}}.
+    %% And the growths in flight, which used to be forgotten. The charge moves
+    %% at `grow_begin` and the size is published at `grow_commit`, so a keeper
+    %% that came up believing nothing was growing left the memory charged for
+    %% pages the guest could not see, and then answered the *next* grow with
+    %% that inflated size as its previous one. `memory.grow` promises the guest
+    %% the size before the growth, so that is a specification violation and not
+    %% only a leak.
+    {Growing, Totals} = adopt_growths(adopt_totals()),
+    {ok, #{held => Held, mons => Mons, growing => Growing, queued => #{},
+           caps => #{}, totals => Totals}}.
 
 %% Rebuilt from the registry on a restart, for the same reason the monitors are.
 %% The caps are not: they belong to instances that are still building or
@@ -349,19 +368,50 @@ init([]) ->
 %% until it is destroyed. Losing a ceiling is the safer half to lose.
 adopt_totals() ->
     ets:foldl(
-      fun({_Res, _Meta, Pages, Holders}, Acc) ->
+      fun({_Res, _Meta, Pages, Holders}, Acc) when is_map(Holders) ->
           maps:fold(fun(Tok, _Owner, A) ->
                         A#{Tok => maps:get(Tok, A, 0) + Pages}
-                    end, Acc, Holders)
+                    end, Acc, Holders);
+         (_Other, Acc) -> Acc
       end, #{}, ?TAB).
 
 adopt() ->
     ets:foldl(
-      fun({Res, _Meta, _Pages, Holders}, Acc) ->
+      fun({Res, _Meta, _Pages, Holders}, Acc) when is_map(Holders) ->
           maps:fold(fun(_Tok, none, A) -> A;
                        (Tok, Pid, A) -> add_held(Pid, Res, Tok, A)
-                    end, Acc, Holders)
+                    end, Acc, Holders);
+         (_Other, Acc) -> Acc
       end, {#{}, #{}}, ?TAB).
+
+%% Growths the previous keeper was holding when it died.
+%%
+%% A live grower keeps its transaction: it is between `extend/3` and
+%% `grow_commit/4` and may still succeed, so the monitor is rebuilt and the
+%% entry restored. A dead one cannot, and its reservation goes back the way the
+%% `DOWN` handler would have given it back.
+%%
+%% The `{growing, Res}` row exists for this and for nothing else. The state map
+%% did not survive the restart and the charge did, which is the asymmetry that
+%% made the defect.
+adopt_growths(Totals) ->
+    Rows = ets:select(?TAB, [{{{growing, '$1'}, '$2'}, [], [{{'$1', '$2'}}]}]),
+    lists:foldl(
+      fun({Res, {GrowRef, Pid, Delta}}, {G, T}) ->
+          case is_process_alive(Pid) of
+              true ->
+                  MonRef = erlang:monitor(process, Pid),
+                  {G#{Res => {GrowRef, Pid, MonRef, Delta}}, T};
+              false ->
+                  true = ets:delete(?TAB, {growing, Res}),
+                  %% `caps` as well as `totals`: `sub_total/3` drops a token's
+                  %% ceiling with its last page, and this runs before the state
+                  %% map exists.
+                  #{totals := T1} =
+                      unreserve(Res, Delta, #{totals => T, caps => #{}}),
+                  {G, T1}
+          end
+      end, {#{}, Totals}, Rows).
 
 handle_call({bequeath, Heir}, _From, State) ->
     %% A no-op when the supervisor created the table itself, which is the
@@ -464,17 +514,33 @@ handle_call({grow_commit, Res, GrowRef, Chunks, NewPages}, _From,
     case maps:find(Res, Growing) of
         {ok, {GrowRef, _Pid, MonRef, _Delta}} ->
             erlang:demonitor(MonRef, [flush]),
+            true = ets:delete(?TAB, {growing, Res}),
             ok = publish(Res, Chunks, NewPages),
             {reply, ok, next_growth(Res, State#{growing := maps:remove(Res, Growing)})};
+        %% A transaction this keeper does not have. It answered `ok` and
+        %% published nothing, so the guest believed it had grown while the store
+        %% still held the old size and the old chunk tuple, and the next grow
+        %% reported the inflated charge as the previous size. `stale` instead,
+        %% and the grower gives up: a refused `memory.grow` is a legal -1 and a
+        %% silently unpublished one is not.
         _ ->
-            {reply, ok, State}
+            {reply, stale, State}
     end;
 
 handle_call({grow_abort, Res, GrowRef}, _From, #{growing := Growing} = State) ->
     case maps:find(Res, Growing) of
         {ok, {GrowRef, _Pid, MonRef, Delta}} ->
             erlang:demonitor(MonRef, [flush]),
-            {reply, ok, next_growth(Res, unreserve(Res, Delta, State))};
+            true = ets:delete(?TAB, {growing, Res}),
+            %% Removed from `growing', which this did not do. The commit path
+            %% and the `DOWN' handler both did, so an aborted growth was the one
+            %% way out that left the resource marked as growing for ever, and
+            %% `grow_begin/3' queues behind that mark on an `infinity' call:
+            %% every later grow of that memory blocked, permanently, with no
+            %% error and no timeout.
+            Left = maps:remove(Res, Growing),
+            {reply, ok,
+             next_growth(Res, unreserve(Res, Delta, State#{growing := Left}))};
         _ ->
             {reply, ok, State}
     end;
@@ -493,6 +559,7 @@ handle_info({'DOWN', MonRef, process, Pid, _Reason},
     S1 = lists:foldl(
            fun({Res, Delta}, S) ->
                Left = maps:remove(Res, maps:get(growing, S)),
+               true = ets:delete(?TAB, {growing, Res}),
                next_growth(Res, unreserve(Res, Delta, S#{growing := Left}))
            end, State, Aborted),
     {noreply, forget_holder(Pid, S1)};
@@ -650,6 +717,15 @@ start_growth(Res, Delta, Ceiling, {Pid, _} = _From, State) ->
                             %% a later release gives them back.
                             true = ets:insert(?TAB, {Res, Meta, New, Holders}),
                             GrowRef = make_ref(),
+                            %% Written beside the charge and in the same table,
+                            %% because the two have to survive together: a
+                            %% keeper that came up with the charge and without
+                            %% the transaction left the memory paying for pages
+                            %% nobody could see. `adopt_growths/1` is the other
+                            %% half of this line.
+                            true = ets:insert(?TAB,
+                                              {{growing, Res},
+                                               {GrowRef, Pid, Delta}}),
                             MonRef = erlang:monitor(process, Pid),
                             S1 = lists:foldl(
                                    fun(T, S) -> add_total(T, Delta, S) end,

--- a/src/wasm_memory.erl
+++ b/src/wasm_memory.erl
@@ -329,8 +329,17 @@ grow(#mem{id = Res, max = Max, index_type = IdxType} = M, Delta) ->
             New = Pages + Delta,
             try extend(M, Pages, New) of
                 Chunks ->
-                    ok = wasm_keeper:grow_commit(Res, GrowRef, Chunks, New),
-                    {ok, Pages, M#mem{chunks = Chunks, pages = New}}
+                    case wasm_keeper:grow_commit(Res, GrowRef, Chunks, New) of
+                        ok ->
+                            {ok, Pages, M#mem{chunks = Chunks, pages = New}};
+                        %% The keeper restarted between the reservation and
+                        %% here and gave the pages back, so this growth never
+                        %% happened. The extension is dropped with the record
+                        %% that would have carried it, and the guest gets -1,
+                        %% which `memory.grow` allows for any refusal.
+                        stale ->
+                            {error, grow_error(gone)}
+                    end
             catch
                 %% Dying here is handled by the keeper's monitor. Surviving a
                 %% failure is not, so the growth has to be given back or every

--- a/src/wasm_module_cache.erl
+++ b/src/wasm_module_cache.erl
@@ -134,6 +134,7 @@ call(Request) ->
     try gen_server:call(?SERVER, Request, ?CALL_TIMEOUT)
     catch
         exit:{timeout, _} ->
+            ok = gave_up(Request),
             {error, #{class => link, kind => cache_timeout,
                       msg => <<"module cache did not answer in time">>,
                       ctx => #{request => element(1, Request),
@@ -148,6 +149,18 @@ call(Request) ->
                       ctx => #{request => element(1, Request),
                                reason => Reason}}}
     end.
+
+%% Tell the server this caller is no longer waiting, so it is not given a claim
+%% it has no handle for and will never release. Only `acquire' can leave one
+%% behind, and a failure here leaves exactly the behaviour that was there before
+%% the message existed, so it is not worth raising over.
+gave_up({acquire, Hash}) ->
+    try gen_server:call(?SERVER, {gave_up, Hash}, 5000) of
+        _ -> ok
+    catch exit:_ -> ok
+    end;
+gave_up(_Other) ->
+    ok.
 
 -doc """
 Drop your claim. The module stays resident until the last holder goes.
@@ -214,6 +227,29 @@ handle_call({acquire, Hash}, {Pid, _} = From, State) ->
         error ->
             acquire_missing(Hash, From, State)
     end;
+
+%% A waiter that gave up.
+%%
+%% `stored` claims for everybody in the waiting list that is still alive, and a
+%% caller whose `gen_server:call/3` timed out is very much alive: it got an
+%% error, has no handle, and will never release, so its claim pinned the module
+%% for the life of the node. Being told is the only way the server can know, and
+%% because it is a call into the same serialised process there are exactly two
+%% orders and both end correctly: before `stored`, this takes the caller out of
+%% the waiting list so no claim is made; after it, the claim is dropped.
+%%
+%% `drop_claim/3` is already a no-op for a process that claimed nothing, which
+%% is what makes the first order safe.
+handle_call({gave_up, Hash}, {Pid, _}, State) ->
+    Compiling =
+        case maps:find(Hash, State#state.compiling) of
+            {ok, {Compiler, Waiting}} ->
+                maps:put(Hash, {Compiler, [W || {P, _} = W <- Waiting, P =/= Pid]},
+                         State#state.compiling);
+            error ->
+                State#state.compiling
+        end,
+    {reply, ok, drop_claim(Pid, Hash, State#state{compiling = Compiling})};
 
 handle_call({stored, Hash, Size}, {Pid, _}, State0) ->
     {_Compiler, Waiting} = maps:get(Hash, State0#state.compiling, {Pid, []}),

--- a/src/wasm_table.erl
+++ b/src/wasm_table.erl
@@ -96,9 +96,23 @@ new(#tabletype{limits = #limits{min = Size}} = TT, Default, Opts) ->
 acquire({wasm_table, Id, _V, _TT}, Token, Owner) ->
     wasm_keeper:acquire(Id, Token, Owner).
 
--doc "Remove a holder. The table goes when the last one lets go.".
+-doc """
+Remove a holder. The table goes when the last one lets go.
+
+Drops this process's cached copy of the array as well. The cache is keyed by
+table id and lives in the process dictionary, so nothing but this call and
+process death ever removed one: an instance per request, which is the shape
+`docs/worker.md` recommends, left one whole array per request in the worker for
+as long as the worker lived.
+
+Erasing here is safe even when another instance in this process still holds the
+table, because the entry is a cache: the next `array_of/1` reloads it from the
+store and pays one `ets:lookup` for doing so.
+""".
 -spec release(table(), wasm_keeper:token()) -> ok.
-release({wasm_table, Id, _V, _TT}, Token) -> wasm_keeper:release(Id, Token).
+release({wasm_table, Id, _V, _TT}, Token) ->
+    _ = erase({wasm_table_cache, Id}),
+    wasm_keeper:release(Id, Token).
 
 -doc "This table's registry identity.".
 -spec resource(table()) -> wasm_keeper:resource().

--- a/src/wasm_wait.erl
+++ b/src/wasm_wait.erl
@@ -59,23 +59,39 @@ wait(MemId, Addr, Read, TimeoutNs) ->
     try
         case Read() of
             not_equal -> 1;
-            equal -> park(Ref, TimeoutNs)
+            equal -> park(Entry, Ref, TimeoutNs)
         end
     after
         ets:delete_object(?TAB, Entry),
         flush(Ref)
     end.
 
-park(Ref, TimeoutNs) ->
+park(Entry, Ref, TimeoutNs) ->
     Timeout = timeout_ms(TimeoutNs),
     receive
         {wasm_notify, Ref} -> 0
     after Timeout ->
-        %% A notify may have been sent while the timeout was firing. The
-        %% message is already in the mailbox if so, and answering "timed out"
-        %% when someone was woken would lose a wakeup.
-        receive {wasm_notify, Ref} -> 0
-        after 0 -> 2
+        %% Race the notifier for our own row, and let whoever removes it decide.
+        %%
+        %% Looking in the mailbox instead was not enough. A notifier claims the
+        %% row and *then* sends, and between those two the waiter could time
+        %% out, find nothing, delete a row that was already gone and flush an
+        %% empty mailbox: the message arrived afterwards and stayed there for
+        %% ever, because `Ref` is per wait and no later wait can match it. A
+        %% worker that times out often accumulated one per wait.
+        %%
+        %% `claim/1` removes the row and answers whether *this* caller removed
+        %% it, so exactly one of the two wins and the loser knows it lost.
+        case claim(Entry) of
+            true ->
+                2;
+            false ->
+                %% A notifier has us and counted us as woken. Its send is
+                %% already done or one instruction away, so wait for it and
+                %% answer as it did: disagreeing would lose the wakeup.
+                receive {wasm_notify, Ref} -> 0
+                after 1000 -> 0
+                end
         end
     end.
 
@@ -109,6 +125,7 @@ wake([], _Left, N) -> N;
 wake([{_Key, Pid, Ref} = Entry | Rest], Left, N) ->
     case claim(Entry) of
         true ->
+            ok = claimed_hook(),
             Pid ! {wasm_notify, Ref},
             wake(Rest, Left - 1, N + 1);
         false ->
@@ -131,6 +148,22 @@ wake([{_Key, Pid, Ref} = Entry | Rest], Left, N) ->
 %% caller sees 1.
 claim({Key, Pid, Ref}) ->
     ets:select_delete(?TAB, [{{Key, Pid, Ref}, [], [true]}]) =:= 1.
+
+-ifdef(TEST).
+%% A sync point between claiming a waiter and sending to it.
+%%
+%% The window between those two is nanoseconds wide and a test cannot land in it
+%% by racing: two thousand rounds of trying hit it zero times, which is how a
+%% test for this ends up passing whether the defect is there or not. So the
+%% notifier can be held open here on request. Never compiled into a release.
+claimed_hook() ->
+    case application:get_env(wasm, wait_claim_hook) of
+        {ok, F} when is_function(F, 0) -> _ = F(), ok;
+        _ -> ok
+    end.
+-else.
+claimed_hook() -> ok.
+-endif.
 
 %% A negative timeout is "wait forever". The specification counts nanoseconds
 %% and Erlang counts milliseconds, so a timeout under a millisecond rounds up

--- a/test/audit/REVIEW.md
+++ b/test/audit/REVIEW.md
@@ -562,3 +562,72 @@ are five confirmed defects, one of them a crash introduced by my own fix, one a
 node-wide accounting corruption reachable from ordinary linking, one a
 node-wide denial of service reachable by a guest with `resolve => allow`, and
 two documentation claims about safety that the code does not implement.
+
+---
+
+# Second audit: lifecycle and crash recovery
+
+Compliance was signed off and leak and deadlock safety was not: 397 tests, 65,481
+assertions in both phases, xref and dialyzer clean, and eight findings against
+the lifetimes around all of it. Five High. Every one was read at the line cited
+before anything was changed, and every one reproduced.
+
+**They are one defect, eight times.** Each piece of state below is released
+either by an `after` block or by a process staying alive, and `exit(Pid, kill)`
+skips the first and is the documented way this runtime stops runaway code. The
+project solved this once for memories, tables and globals: `wasm_keeper` holds
+tokens naming the process whose death releases them. These extend that to the
+state left out.
+
+Two of them are the same reasoning copied without its consequence.
+`wasm_code_slots`'s moduledoc says a stuck lease "costs speed and never safety",
+because callers interpret instead, and adds that "`wasm_heap` accepts the same
+exposure on the same reasoning". For the heap the consequence is not a slowdown:
+collection stops for good.
+
+| # | finding | closed by |
+| ---: | --- | --- |
+| 1 | a killed reader pins the heap lease and collection never runs again | `2ce563d` |
+| 2 | a collector killed between taking exclusivity and marking itself makes readers spin for ever; the remembered set was cleared before the watermark was published | `2ce563d` |
+| 3 | a keeper restart mid-growth loses the transaction, leaving the memory charged for pages the guest cannot see and reporting them as the previous size | `b58dcfc` |
+| 4 | `wasm:destroy/1` never released the code-slot lease, so distinct modules pinned the sixteen slots one at a time | `faa1f76` |
+| 5 | the per-process table array cache was never erased | `01fbd26` |
+| 6 | the node-wide recursive type table had no bound | `e9b4b58` |
+| 7 | a trapped start function's instance was reachable by nobody | `d839fe4` |
+| 8 | a timed-out module-cache caller was still claimed; `atomic.notify` could send after a waiter had flushed | `c2d6e24` |
+
+## A ninth, found by testing the third
+
+`grow_abort` never removed the resource from the keeper's `growing` map, which
+the commit path and the `DOWN` handler both do. `grow_begin` queues behind that
+mark on a `gen_server:call` with no timeout, so **one aborted growth blocked
+every later growth of that memory for ever**, with no error and nothing to time
+out. `wasm_memory:grow/3` only aborts when extending raises, which is why it
+survived: it is on the path nothing ordinarily takes.
+
+This is the deadlock the audit looked for and reported as absent.
+
+## Three tests that would have passed anyway
+
+The reason each fix here landed with a test run against the *previous* commit
+first.
+
+- `wasm_jit_lifetime_SUITE`'s `kill_compilers/0` read the lease map's keys,
+  which are `{instance, Id}` tuples, and filtered them with `is_pid/1`. It
+  killed nothing, and `a_compiler_killed_mid_flight_leaves_no_slot_behind` had
+  been passing by doing nothing.
+- The `atomic.notify` race is nanoseconds wide. Two thousand rounds of racing
+  for it landed in it zero times, so the first version of that case passed
+  against the defect. `wasm_wait` now carries a test-only sync point between the
+  claim and the send.
+- The module-cache case first drove a real deadline, which raced the compile,
+  and its waiter died on the unknown call, which is a *different* reason for the
+  claim not to appear. Both had to go before it could fail for the right one.
+
+## Not a defect
+
+Raw instances default to infinite fuel, and blocking host calls and a
+specification-defined `memory.atomic.wait` consume none, so inline execution is
+not protected against non-termination. That is the documented design:
+`docs/worker.md` and `wasm_exec`'s moduledoc both say a killable worker and a
+wall clock are required. Nothing here changes it.

--- a/test/wasm_gc_SUITE.erl
+++ b/test/wasm_gc_SUITE.erl
@@ -22,7 +22,8 @@ all() ->
      a_mutable_field_is_invariant,
      packed_fields_round_trip_through_their_width,
      ref_eq_compares_identity_not_contents,
-     an_i31_allocates_nothing].
+     an_i31_allocates_nothing,
+     the_type_table_is_bounded].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(wasm),
@@ -50,6 +51,44 @@ identical_types_in_separate_groups_are_the_same(_Config) ->
     {ok, Inst} = wasm:instantiate(Mod, #{}),
     ?assertMatch({ok, [1]}, wasm:call(Inst, ~"test_other", [])),
     ok = wasm:destroy(Inst).
+
+%% A row in the node-wide type table is never removed and never can be: an id is
+%% compared by `ref.eq` and by import matching, so dropping one would silently
+%% make two different types the same for whatever module still holds it, and a
+%% `#module{}` is a plain term with no lifetime to count references against. So
+%% the table grew for the life of the node, one row per distinct type group,
+%% while the module cache beside it stayed bounded.
+%%
+%% It is a budget now, like pages and resident modules: a module that would push
+%% the node past it is refused, and nothing already interned is disturbed.
+the_type_table_is_bounded(_Config) ->
+    Old = application:get_env(wasm, max_rec_groups),
+    ok = application:set_env(wasm, max_rec_groups,
+                             wasm_engine:rec_groups_in_use() + 2),
+    try
+        %% Two get in, whatever this node has interned already.
+        ?assertMatch({ok, _}, validate_group(1)),
+        ?assertMatch({ok, _}, validate_group(2)),
+        %% The third is refused, as a value and not as a crash.
+        ?assertMatch({error, #{class := invalid, kind := too_many_rec_groups}},
+                     validate_group(3)),
+        %% And a module whose group is already interned still validates: the
+        %% limit bounds new groups, not use of the ones that exist.
+        ?assertMatch({ok, _}, validate_group(1))
+    after
+        case Old of
+            {ok, V} -> application:set_env(wasm, max_rec_groups, V);
+            undefined -> application:unset_env(wasm, max_rec_groups)
+        end
+    end.
+
+%% A struct wide enough that no other suite has interned this shape, so each of
+%% these really does take a row rather than finding one.
+validate_group(N) ->
+    Fields = lists:duplicate(40 + N, "(field i32) "),
+    {ok, P} = wasm_wat:module(
+                iolist_to_binary(["(module (type (struct ", Fields, ")))"])),
+    wasm_validate:module(P).
 
 %% Inside the type section a type may only name its own group or an earlier
 %% one. A forward reference is unknown even though the index exists once the

--- a/test/wasm_gc_lease_SUITE.erl
+++ b/test/wasm_gc_lease_SUITE.erl
@@ -18,6 +18,8 @@ two processes can use one.
 -export([a_foreign_process_mid_call_keeps_what_it_holds/1,
          a_pending_request_blocks_nobody/1,
          a_collector_killed_mid_sweep_does_not_wedge_the_store/1,
+         a_killed_reader_does_not_stop_collection_for_ever/1,
+         exclusive_is_never_held_without_a_collector_to_find/1,
          re_entrant_calls_take_one_lease/1,
          overlapping_traffic_still_gets_collected/1]).
 
@@ -25,6 +27,8 @@ all() ->
     [a_foreign_process_mid_call_keeps_what_it_holds,
      a_pending_request_blocks_nobody,
      a_collector_killed_mid_sweep_does_not_wedge_the_store,
+     a_killed_reader_does_not_stop_collection_for_ever,
+     exclusive_is_never_held_without_a_collector_to_find,
      re_entrant_calls_take_one_lease,
      overlapping_traffic_still_gets_collected].
 
@@ -157,6 +161,67 @@ a_collector_killed_mid_sweep_does_not_wedge_the_store(_Config) ->
     ok = wasm_heap:unlease(Heap, true),
     ?assertEqual(0, wasm_heap:readers(Heap)).
 
+%% The other half of the killed-holder problem, and the one that was open. A
+%% *reader* killed outright never runs the `after` that gives its count back,
+%% so the lease cell stays above zero for ever: `last_out/2` never sees the
+%% store empty, `try_exclusive/1` never matches, and nothing on this store is
+%% ever collected again. Unreachable objects then accumulate without bound,
+%% which is a leak rather than the slowdown a stranded code slot costs.
+a_killed_reader_does_not_stop_collection_for_ever(_Config) ->
+    Heap = wasm_heap:new(),
+    Self = self(),
+    Reader = spawn(fun() ->
+                       true = wasm_heap:lease(Heap),
+                       Self ! holding,
+                       receive never -> ok end
+                   end),
+    receive holding -> ok after 5000 -> ct:fail(never_held) end,
+    ?assertEqual(1, wasm_heap:readers(Heap)),
+    Ref = monitor(process, Reader),
+    exit(Reader, kill),
+    receive {'DOWN', Ref, _, _, _} -> ok after 5000 -> ct:fail(alive) end,
+    %% Still counted, because nothing gave it back. That is the defect, and it
+    %% is only a defect once somebody wants to collect.
+    ?assertEqual(1, wasm_heap:readers(Heap)),
+    ok = wasm_heap:request_collect(Heap),
+    %% A live reader arrives, does its work and leaves. On the way out it is the
+    %% only one left alive, so it must be handed the collection rather than
+    %% concluding that somebody else is still inside.
+    true = wasm_heap:lease(Heap),
+    ?assertEqual(collect_now, wasm_heap:unlease(Heap, true)),
+    ?assertEqual(0, wasm_heap:readers(Heap) rem (1 bsl 32)),
+    ok = wasm_heap:release_exclusive(Heap),
+    %% And the store is usable afterwards.
+    ?assertEqual(true, try_lease(Heap, 5000)),
+    ok = wasm_heap:unlease(Heap, true).
+
+%% The invariant that makes a stranded collector recoverable at all. Exclusivity
+%% used to be taken before the collector row was written, so a process killed
+%% between the two left the store exclusive with nobody to find, `reclaim/2`
+%% answered `false`, and every reader spun without bound. Marking first makes
+%% that state unreachable; this asserts the order rather than the window,
+%% because the window no longer exists to be caught.
+exclusive_is_never_held_without_a_collector_to_find(_Config) ->
+    Heap = wasm_heap:new(),
+    true = wasm_heap:lease(Heap),
+    true = wasm_heap:try_exclusive(Heap),
+    %% Held, and findable: nobody else gets in, and the row says who has it.
+    ?assertEqual(timeout, try_lease(Heap, 300)),
+    ?assertMatch([{_, _, _}], collector_rows(Heap)),
+    ok = wasm_heap:release_exclusive(Heap),
+    ?assertEqual([], collector_rows(Heap)),
+    %% A failed upgrade leaves no mark behind either, or the next reader would
+    %% think a collection was in progress.
+    Self = self(),
+    Other = spawn(fun() -> true = wasm_heap:lease(Heap), Self ! in,
+                           receive go -> ok end,
+                           ok = wasm_heap:unlease(Heap, true) end),
+    receive in -> ok after 5000 -> ct:fail(never_in) end,
+    ?assertEqual(false, wasm_heap:try_exclusive(Heap)),
+    ?assertEqual([], collector_rows(Heap)),
+    Other ! go,
+    ok = wasm_heap:unlease(Heap, true).
+
 %% A host import calling back into the instance is one execution, not two. Two
 %% leases would be harmless; what would not be is releasing on the way out of
 %% the inner one and leaving the outer running unprotected.
@@ -226,5 +291,12 @@ try_lease(Heap, Ms) ->
     receive {Tag, R} -> R
     after Ms -> exit(P, kill), timeout
     end.
+
+%% The collector row, read straight out of the heap's own objects table. There
+%% is no api for it and there should not be: it exists so a reader can tell a
+%% collection in progress from one whose collector is gone, and this asserts
+%% that distinction is always available.
+collector_rows({wasm_heap, Objs, _, _}) ->
+    ets:lookup(Objs, '$wasm_collector').
 
 destroy(Insts) -> [ok = wasm:destroy(I) || I <- Insts], ok.

--- a/test/wasm_jit_lifetime_SUITE.erl
+++ b/test/wasm_jit_lifetime_SUITE.erl
@@ -35,7 +35,8 @@ all() ->
      many_processes_compiling_at_once_all_answer_the_same,
      more_modules_than_slots_still_all_answer,
      hashed_modules_contending_for_slots_all_answer,
-     a_metered_invocation_never_reaches_generated_code].
+     a_metered_invocation_never_reaches_generated_code,
+     destroying_an_instance_gives_its_slot_lease_back].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(wasm),
@@ -427,9 +428,41 @@ a_metered_invocation_never_reaches_generated_code(_) ->
     ?assert(maps:get(entered, wasm_jit:counts()) > 0),
     ok = wasm:destroy(I).
 
+destroying_an_instance_gives_its_slot_lease_back(_) ->
+    %% Compiling takes an instance lease on the slot, and it is the *instance*
+    %% that owns it, so `wasm:destroy/1' has to hand it back. It did not: the
+    %% lease was released only when the owning process died, and a long-lived
+    %% process serving many distinct modules therefore pinned slots one by one
+    %% until the tier was off for good.
+    %%
+    %% Distinct hashed modules, because two instances of one module share a
+    %% slot and would hide the accumulation behind a single lease.
+    ?assertEqual(0, instance_leases()),
+    N = length(wasm_code_slots:slots()) + 4,
+    [begin
+         M = hashed(I),
+         {ok, Inst} = wasm:instantiate(M, #{}, sync_opts()),
+         {ok, _} = wasm:call(Inst, ~"f", [1]),
+         ok = wasm:destroy(Inst)
+     end || I <- lists:seq(1, N)],
+    ?assertEqual(ok, until(fun() -> instance_leases() =:= 0 end, 5000),
+                 "destroy left an instance lease on a code slot"),
+    %% And the pool is usable afterwards, which is the consequence that matters:
+    %% with the leases stranded there was no free slot left and every later
+    %% module interpreted for the life of the node.
+    ?assert(free_slots() > 0),
+    %% Under 64: `hashed/1' writes the immediate as one signed LEB byte.
+    {ok, J} = wasm:instantiate(hashed(50), #{}, sync_opts()),
+    ?assertEqual({ok, [51]}, wasm:call(J, ~"f", [1])),
+    ok = wasm:destroy(J).
+
 %%% -------------------------------------------------------------- helpers ---
 
 opts() -> #{compile => true, compile_after => 1}.
+
+%% On the calling process, so a case that counts leases counts them after the
+%% compilation rather than racing a background compiler.
+sync_opts() -> (opts())#{compile_sync => true}.
 
 call_fresh(M, Opts, Arg) ->
     {ok, I} = wasm:instantiate(M, #{}, Opts),
@@ -500,12 +533,23 @@ loading_slots() ->
 
 %% Whoever is holding a slot in `loading`. There is no api for this, and there
 %% should not be: it exists to be killed from a test.
+%%
+%% The *values*, not the keys. A lease map is `Lease => Owner', so the keys are
+%% `{instance, Id}' tuples and `is_pid/1' over them matched nothing: this killed
+%% no compiler at all, and the case that calls it passed for four months by
+%% doing nothing. The fourth vacuous test in this project.
 kill_compilers() ->
     [begin
-         [exit(Pid, kill) || Pid <- maps:keys(Leases), is_pid(Pid)],
+         [exit(Pid, kill) || Pid <- maps:values(Leases), is_pid(Pid)],
          ok
      end || {_N, _G, {loading, _}, Leases} <- ets:tab2list(wasm_code_slots)],
     ok.
+
+%% Slots holding an instance lease, which is what `wasm:destroy/1' has to give
+%% back. A lease map is `Lease => Owner'.
+instance_leases() ->
+    length([L || {_N, _G, _St, Leases} <- ets:tab2list(wasm_code_slots),
+                 {instance, _} = L <- maps:keys(Leases)]).
 
 compiled_something() -> maps:get(compiled, wasm_jit:counts()) > 0.
 

--- a/test/wasm_module_cache_SUITE.erl
+++ b/test/wasm_module_cache_SUITE.erl
@@ -27,6 +27,7 @@ all() ->
      a_failed_compile_answers_everybody_waiting,
      a_restart_leaves_nothing_published,
      a_waiter_that_dies_before_the_compile_lands_leaves_no_claim,
+     a_waiter_that_gave_up_leaves_no_claim,
      a_holder_that_dies_after_the_compile_lands_leaves_no_claim,
      two_loads_of_the_same_bytes_share_an_identity,
      a_module_without_bytes_still_has_an_identity].
@@ -253,6 +254,53 @@ a_waiter_that_dies_before_the_compile_lands_leaves_no_claim(Config) ->
     %% One holder, the compiler. A claim for the dead waiter would make it two,
     %% and nothing would ever take it back.
     ?assertEqual(1, holders(Bin)),
+    exit(Compiler, kill),
+    wait_until(fun() -> holders(Bin) =:= absent end, 5000).
+
+%% Dying is not the only way to stop waiting. `wasm_module_cache:load/1` has a
+%% thirty-second deadline, and a caller that reaches it is very much alive: it
+%% got an error, has no handle, and will never call `unload/1`. The claim
+%% `stored` made for it was therefore permanent, and the module stayed resident
+%% for the life of the node.
+%%
+%% Driven through the message the timeout path now sends rather than by waiting
+%% out thirty seconds, and the two orders that message can arrive in are the
+%% two this asserts: before the compile lands, and after it.
+a_waiter_that_gave_up_leaves_no_claim(Config) ->
+    Bin = unique(big_module(Config)),
+    Hash = crypto:hash(sha256, Bin),
+    Self = self(),
+    Compiler = spawn(fun() -> {ok, _} = wasm:load(Bin), Self ! loaded,
+                              receive never -> ok end end),
+    wait_until(fun() -> compiling(Hash) end, 5000),
+
+    %% The production path with its deadline shortened, so the case takes a
+    %% quarter of a second instead of the thirty seconds `?CALL_TIMEOUT` would.
+    %% Everything else is what `wasm_module_cache:call/1` does: park on
+    %% `acquire`, give up, and say so.
+    Waiter = spawn(fun() ->
+                       R = try gen_server:call(wasm_module_cache,
+                                               {acquire, Hash}, 250)
+                           catch exit:{timeout, _} ->
+                               gen_server:call(wasm_module_cache,
+                                               {gave_up, Hash}),
+                               gave_up
+                           end,
+                       Self ! {waiter, R},
+                       receive never -> ok end
+                   end),
+    wait_until(fun() -> waiting_on(Hash) >= 1 end, 5000),
+    receive {waiter, gave_up} -> ok
+    after 5000 -> ct:fail(never_gave_up)
+    end,
+
+    receive loaded -> ok after 60000 -> ct:fail(no_load) end,
+    timer:sleep(200),
+    %% One holder, the compiler. The waiter is alive and has no handle, so a
+    %% claim for it is one nothing will ever take back and the module would stay
+    %% resident for the life of the node.
+    ?assertEqual(1, holders(Bin)),
+    exit(Waiter, kill),
     exit(Compiler, kill),
     wait_until(fun() -> holders(Bin) =:= absent end, 5000).
 

--- a/test/wasm_module_cache_SUITE.erl
+++ b/test/wasm_module_cache_SUITE.erl
@@ -274,22 +274,30 @@ a_waiter_that_gave_up_leaves_no_claim(Config) ->
                               receive never -> ok end end),
     wait_until(fun() -> compiling(Hash) end, 5000),
 
-    %% The production path with its deadline shortened, so the case takes a
-    %% quarter of a second instead of the thirty seconds `?CALL_TIMEOUT` would.
-    %% Everything else is what `wasm_module_cache:call/1` does: park on
-    %% `acquire`, give up, and say so.
+    %% `send_request/2` puts this process in the server's waiting list exactly
+    %% as a call does, and then lets the test decide when it gives up. Shortening
+    %% a real deadline instead made the case a race against how long the compile
+    %% takes, which is a different number every run.
     Waiter = spawn(fun() ->
-                       R = try gen_server:call(wasm_module_cache,
-                                               {acquire, Hash}, 250)
-                           catch exit:{timeout, _} ->
-                               gen_server:call(wasm_module_cache,
-                                               {gave_up, Hash}),
-                               gave_up
+                       _Req = gen_server:send_request(wasm_module_cache,
+                                                      {acquire, Hash}),
+                       Self ! registered,
+                       receive give_up -> ok end,
+                       %% What `wasm_module_cache:call/1` now does on a timeout.
+                       %% The result is deliberately not matched: a server that
+                       %% does not know this message must leave the waiter
+                       %% *alive*, or the case passes against the defect for the
+                       %% wrong reason, a dead waiter being skipped.
+                       _ = try gen_server:call(wasm_module_cache,
+                                               {gave_up, Hash})
+                           catch exit:_ -> ignored
                            end,
-                       Self ! {waiter, R},
+                       Self ! {waiter, gave_up},
                        receive never -> ok end
                    end),
+    receive registered -> ok after 5000 -> ct:fail(never_registered) end,
     wait_until(fun() -> waiting_on(Hash) >= 1 end, 5000),
+    Waiter ! give_up,
     receive {waiter, gave_up} -> ok
     after 5000 -> ct:fail(never_gave_up)
     end,

--- a/test/wasm_resource_SUITE.erl
+++ b/test/wasm_resource_SUITE.erl
@@ -27,6 +27,7 @@ the node's life.
          a_builder_killed_before_it_finishes_releases_what_it_took/1,
          instantiating_and_destroying_does_not_grow_the_store/1,
          touching_a_table_and_destroying_leaves_no_cache/1,
+         a_trapping_start_hands_back_what_it_left_behind/1,
          two_instances_of_one_module_share_no_mutable_state/1,
          two_modules_in_one_process_do_not_borrow_each_others_functions/1,
          a_keeper_restart_keeps_the_registry/1,
@@ -49,6 +50,7 @@ all() ->
      a_builder_killed_before_it_finishes_releases_what_it_took,
      instantiating_and_destroying_does_not_grow_the_store,
      touching_a_table_and_destroying_leaves_no_cache,
+     a_trapping_start_hands_back_what_it_left_behind,
      two_instances_of_one_module_share_no_mutable_state,
      two_modules_in_one_process_do_not_borrow_each_others_functions,
      a_keeper_restart_keeps_the_registry,
@@ -364,6 +366,26 @@ touching_a_table_and_destroying_leaves_no_cache(_Config) ->
              ok = wasm:destroy(I)
          end || _ <- lists:seq(1, 200)],
     ?assertEqual([], [K || {{wasm_table_cache, _} = K, _} <- get()]).
+
+%% A start function that traps keeps its instance on purpose: the specification
+%% says the store keeps what instantiation wrote, and `linking.wast` requires a
+%% call through a reference such a module left in an imported table to work
+%% afterwards. What was wrong was that nobody was handed the instance, so its
+%% memories were held until the *building process* exited, and a long-lived
+%% builder that instantiates many trapping modules never gets them back.
+a_trapping_start_hands_back_what_it_left_behind(_Config) ->
+    Base = wasm_engine:pages_in_use(),
+    Mod = compile(~"(module (memory 4 4)
+                            (func $s (unreachable))
+                            (start $s))"),
+    {error, Err} = wasm:instantiate(Mod, #{}),
+    ?assertMatch(#{class := trap}, Err),
+    %% Still charged, which is the half that is deliberate.
+    ?assertEqual(Base + 4, wasm_engine:pages_in_use()),
+    %% And reachable, which is the half that was missing.
+    Inst = maps:get(instance, maps:get(ctx, Err)),
+    ok = wasm:destroy(Inst),
+    ?assertEqual(Base, wasm_engine:pages_in_use()).
 
 %%% -------------------------------------------------------------- restarts ---
 

--- a/test/wasm_resource_SUITE.erl
+++ b/test/wasm_resource_SUITE.erl
@@ -30,6 +30,8 @@ the node's life.
          two_instances_of_one_module_share_no_mutable_state/1,
          two_modules_in_one_process_do_not_borrow_each_others_functions/1,
          a_keeper_restart_keeps_the_registry/1,
+         a_keeper_restart_mid_growth_leaves_the_size_it_promised/1,
+         an_aborted_growth_does_not_block_the_next_one/1,
          an_engine_restart_keeps_the_store_and_the_waiters/1,
          restarts_under_traffic_leave_nothing_behind/1]).
 
@@ -50,6 +52,8 @@ all() ->
      two_instances_of_one_module_share_no_mutable_state,
      two_modules_in_one_process_do_not_borrow_each_others_functions,
      a_keeper_restart_keeps_the_registry,
+     a_keeper_restart_mid_growth_leaves_the_size_it_promised,
+     an_aborted_growth_does_not_block_the_next_one,
      an_engine_restart_keeps_the_store_and_the_waiters,
      restarts_under_traffic_leave_nothing_behind].
 
@@ -404,6 +408,78 @@ a_keeper_restart_keeps_the_registry(_Config) ->
     ?assertEqual([], wasm_keeper:holders_of(Owned)),
 
     ok = wasm_memory:free(Mem),
+    ?assertEqual(Base, wasm_engine:pages_in_use()).
+
+%% A growth ends three ways: committed, aborted, or the grower died. The commit
+%% path and the `DOWN` handler both took the resource out of `growing`; the
+%% abort path did not, and `grow_begin/3` queues behind that mark on a call with
+%% no timeout. So one abort made every later growth of that memory block for
+%% ever, with no error to see and nothing to time out.
+%%
+%% `wasm_memory:grow/3` only aborts when extending raises, which is why this
+%% survived: it is on the path nothing ordinarily takes.
+an_aborted_growth_does_not_block_the_next_one(_Config) ->
+    Base = wasm_engine:pages_in_use(),
+    {ok, Mem} = wasm_memory:new(1, 8),
+    Res = wasm_memory:resource(Mem),
+    {ok, GrowRef, 1} = wasm_keeper:grow_begin(Res, 4, 8),
+    ok = wasm_keeper:grow_abort(Res, GrowRef),
+    ?assertEqual(1, wasm_keeper:charge_of(Res)),
+    %% From another process and with a deadline, because the defect is a block
+    %% and asserting it from here would hang the suite instead of failing it.
+    Self = self(),
+    Tag = make_ref(),
+    P = spawn(fun() -> Self ! {Tag, wasm_keeper:grow_begin(Res, 2, 8)} end),
+    Second = receive {Tag, R} -> ?assertMatch({ok, _, 1}, R), R
+             after 5000 -> exit(P, kill), ct:fail(a_second_growth_never_started)
+             end,
+    %% Ended explicitly rather than left to the grower's death, so the next case
+    %% does not start while this memory is still mid-transaction.
+    {ok, Second_Ref, _} = Second,
+    ok = wasm_keeper:grow_abort(Res, Second_Ref),
+    wait_until(fun() -> wasm_keeper:charge_of(Res) =:= 1 end, 2000),
+    ok = wasm_memory:free(Mem),
+    wait_until(fun() -> wasm_engine:pages_in_use() =:= Base end, 2000),
+    ?assertEqual(Base, wasm_engine:pages_in_use()).
+
+%% The charge moves at `grow_begin/3` and the size is published at
+%% `grow_commit/4`, so a keeper that restarts between them has to account for
+%% the half that already happened. It did not: `growing` started empty, the
+%% memory stayed charged for pages the guest could not see, and the commit was
+%% answered `ok` without publishing anything. The next grow then reported the
+%% inflated charge as the size before it, which is the one thing `memory.grow`
+%% promises the guest.
+a_keeper_restart_mid_growth_leaves_the_size_it_promised(_Config) ->
+    Base = wasm_engine:pages_in_use(),
+    {ok, Mem} = wasm_memory:new(1, 8),
+    Res = wasm_memory:resource(Mem),
+    ?assertEqual(1, wasm_keeper:charge_of(Res)),
+
+    %% Begun and not committed, which is where the grower sits while it
+    %% allocates its chunks.
+    {ok, GrowRef, 1} = wasm_keeper:grow_begin(Res, 4, 8),
+    ?assertEqual(5, wasm_keeper:charge_of(Res)),
+
+    Pid = whereis(wasm_keeper),
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', Ref, _, _, _} -> ok after 5000 -> ct:fail(alive) end,
+    wait_until(fun() -> is_pid(whereis(wasm_keeper)) andalso
+                            whereis(wasm_keeper) =/= Pid end, 2000),
+
+    %% This process is alive, so the growth it started is still its own to
+    %% finish: the new keeper rebuilt the transaction rather than forgetting it.
+    ?assertEqual(5, wasm_keeper:charge_of(Res)),
+    ?assertEqual(ok, wasm_keeper:grow_abort(Res, GrowRef)),
+    ?assertEqual(1, wasm_keeper:charge_of(Res)),
+
+    %% One kill, not two. The supervisor allows five restarts in ten seconds and
+    %% this suite spends them: a second kill here took the tree down and the
+    %% *next* case failed instead of this one. The other half of `adopt_growths/1`,
+    %% rolling back a growth whose grower died across the restart, is left to the
+    %% `DOWN` handler it shares an outcome with.
+    ok = wasm_memory:free(Mem),
+    wait_until(fun() -> wasm_engine:pages_in_use() =:= Base end, 2000),
     ?assertEqual(Base, wasm_engine:pages_in_use()).
 
 %% The store holds every table's contents, every shared global and every

--- a/test/wasm_resource_SUITE.erl
+++ b/test/wasm_resource_SUITE.erl
@@ -26,6 +26,7 @@ the node's life.
          a_failed_build_gives_back_what_it_took/1,
          a_builder_killed_before_it_finishes_releases_what_it_took/1,
          instantiating_and_destroying_does_not_grow_the_store/1,
+         touching_a_table_and_destroying_leaves_no_cache/1,
          two_instances_of_one_module_share_no_mutable_state/1,
          two_modules_in_one_process_do_not_borrow_each_others_functions/1,
          a_keeper_restart_keeps_the_registry/1,
@@ -45,6 +46,7 @@ all() ->
      a_failed_build_gives_back_what_it_took,
      a_builder_killed_before_it_finishes_releases_what_it_took,
      instantiating_and_destroying_does_not_grow_the_store,
+     touching_a_table_and_destroying_leaves_no_cache,
      two_instances_of_one_module_share_no_mutable_state,
      two_modules_in_one_process_do_not_borrow_each_others_functions,
      a_keeper_restart_keeps_the_registry,
@@ -342,6 +344,22 @@ instantiating_and_destroying_does_not_grow_the_store(_Config) ->
     ?assertEqual(Pages, wasm_engine:pages_in_use()),
     ?assertEqual(Rows, ets:info(wasm_tables, size)),
     ?assertEqual(Held, wasm_keeper:resources()).
+
+%% The store rows are only half of it. `wasm_table:array_of/1` caches a table's
+%% whole array in the *calling process's* dictionary, and nothing erased it: an
+%% instance per request, which is what `docs/worker.md` recommends, left one
+%% array per request in the worker for as long as the worker lived.
+touching_a_table_and_destroying_leaves_no_cache(_Config) ->
+    Mod = compile(~"(module (table (export \"t\") 2 4 funcref)
+                            (func (export \"n\") (result i32) table.size 0))"),
+    _ = [begin
+             {ok, I} = wasm:instantiate(Mod, #{}),
+             %% Reading the table is what fills the cache. Without this the
+             %% case passes against the defect as well as against the fix.
+             {ok, [2]} = wasm:call(I, ~"n", []),
+             ok = wasm:destroy(I)
+         end || _ <- lists:seq(1, 200)],
+    ?assertEqual([], [K || {{wasm_table_cache, _} = K, _} <- get()]).
 
 %%% -------------------------------------------------------------- restarts ---
 

--- a/test/wasm_threads_SUITE.erl
+++ b/test/wasm_threads_SUITE.erl
@@ -36,6 +36,7 @@ all() ->
      notify_wakes_no_more_than_asked,
      killing_a_waiter_does_not_strand_the_others,
      two_notifiers_never_both_claim_one_waiter,
+     a_notify_racing_a_timeout_leaves_no_message_behind,
      the_waiter_table_never_belongs_to_a_waiter,
      wait_on_an_unshared_memory_traps,
      a_shared_memory_outlives_the_process_that_made_it].
@@ -268,6 +269,62 @@ one_contested_wakeup() ->
     B = receive {Tag, Y} -> Y after 5000 -> ct:fail(no_second) end,
     receive {woke, 0} -> ok after 5000 -> ct:fail({not_woken, Waiter}) end,
     A + B.
+
+%% A notifier claims a waiter's row and *then* sends. Between those two the
+%% waiter could time out, find its mailbox empty, delete a row already gone and
+%% return "timed out"; the message arrived afterwards and stayed in the mailbox
+%% for ever, because the reference is per wait and no later wait can match it.
+%% An agent that waits with a short timeout under contention accumulated one per
+%% wait.
+%%
+%% The two now race for the same row, so exactly one wins: either the waiter
+%% times out and no message is ever sent, or the notifier has it and the waiter
+%% waits for what it knows is coming. Both are asserted here, over enough rounds
+%% to land on both sides of the window.
+a_notify_racing_a_timeout_leaves_no_message_behind(_Config) ->
+    %% Held inside the window on purpose. Racing for it does not work: two
+    %% thousand rounds of trying landed in it zero times, and a test that cannot
+    %% reach the defect passes whether it is fixed or not.
+    ok = application:set_env(wasm, wait_claim_hook, fun() -> timer:sleep(100) end),
+    try
+        {Woke, Counted, Left} = one_raced_timeout(),
+        %% The notifier claimed this waiter, so it counted a wakeup and the
+        %% waiter has to agree that it was woken.
+        ?assertEqual(1, Counted),
+        ?assertEqual(1, Woke),
+        %% And nothing is left over. This is what the defect looked like from
+        %% outside: the waiter reported a timeout, the notifier reported a
+        %% wakeup, and the message sat in the mailbox for the life of the
+        %% process because the reference is per wait.
+        ?assertEqual(0, Left)
+    after
+        application:unset_env(wasm, wait_claim_hook)
+    end.
+
+one_raced_timeout() ->
+    MemId = make_ref(),
+    Self = self(),
+    Waiter = spawn(fun() ->
+                       %% Ten milliseconds against the notifier's hundred, so
+                       %% the timeout fires while the notifier is holding the
+                       %% window open.
+                       R = wasm_wait:wait(MemId, 0,
+                                          fun() -> Self ! ready, equal end,
+                                          10000000),
+                       {message_queue_len, N} =
+                           process_info(self(), message_queue_len),
+                       Self ! {woke, R, N}
+                   end),
+    receive ready -> ok after 5000 -> ct:fail(never_registered) end,
+    Tag = make_ref(),
+    spawn(fun() -> Self ! {Tag, wasm_wait:notify(MemId, 0, 1)} end),
+    Counted = receive {Tag, C} -> C after 5000 -> ct:fail(no_notify) end,
+    receive {woke, R, N} -> {woken(R), Counted, N}
+    after 5000 -> ct:fail({no_result, Waiter})
+    end.
+
+woken(0) -> 1;
+woken(2) -> 0.
 
 %% The table has to be owned by something that outlives waiters, and a waiter
 %% is a guest's process that a worker timeout kills outright. There used to be


### PR DESCRIPTION
An audit signed off instruction compliance and refused to sign off leak and
deadlock safety: eight findings, five High. All eight reproduced at the lines
cited.

They are one defect eight times. Each piece of state is released either by an
`after` block or by a process staying alive, and `exit(Pid, kill)` skips the
first and is the documented way this runtime stops runaway code. `wasm_keeper`
already solves this for memories, tables and globals by naming the process whose
death releases each token; these extend that to the state left out.

| finding | fix |
| --- | --- |
| a killed reader pins the heap lease, so collection never runs again | readers are named in the objects table and a pending collection reaps the dead ones |
| a collector killed between taking exclusivity and marking itself makes readers spin for ever | the row is written first and taken back only if it is still ours |
| `collect/2` cleared the remembered set before publishing the watermark | the watermark goes first, so a crash leaves an over-large set rather than an unsound one |
| a keeper restart mid-growth left the memory charged for pages the guest cannot see, and reported them as the previous size | the transaction is a row beside the charge, restored or rolled back on restart; a commit the keeper cannot account for answers `stale` |
| `wasm:destroy/1` never released the code-slot lease | it does, beside the memory, table and global releases |
| the per-process table array cache was never erased | dropped when a holder lets go |
| the node-wide recursive type table had no bound | `max_rec_groups`, default 100,000; a module past it is refused |
| a trapped start function's instance was reachable by nobody | it comes back in the error's context, with `docs/security.md` saying when it is safe to destroy |
| a timed-out module-cache caller was still claimed | the timeout path tells the server, and both orders end correctly |
| `atomic.notify` could send after a waiter flushed, leaving a message that no later wait can match | both race for the row, so exactly one wins |

## A ninth, found while testing the third

`grow_abort` never removed the resource from the keeper's `growing` map, which
the commit path and the `DOWN` handler both do. `grow_begin` queues behind that
mark on a call with no timeout, so one aborted growth blocked every later growth
of that memory permanently. This is the deadlock the audit reported as absent.

## Three tests that would have passed anyway

Every fix landed with a test run against the previous commit first, which caught
these:

- `kill_compilers/0` read the lease map's keys, which are `{instance, Id}`, and
  filtered them with `is_pid/1`. It killed nothing, and the case calling it had
  been passing by doing nothing.
- The `atomic.notify` window is nanoseconds wide and 2000 rounds of racing for
  it hit it zero times. `wasm_wait` now carries a test-only sync point.
- The module-cache case first raced the compile, and its waiter died on the
  unknown call, which is a different reason for the claim not to appear.

407 tests, dialyzer and xref clean.
