### PR TITLE
Take the text format in wasm:compile/1, and cut 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.1.1
+
+`wasm:compile/1` takes the text format:
+
+```erlang
+{ok, M} = wasm:compile({wat, ~"(module (func (export \"f\") (result i32) i32.const 7))"}).
+```
+
+`load/1` still takes the binary format only: the cache is keyed on a content
+hash, and a module built from text takes a fresh identity every time.
+
+### Fixed
+
+Seven lifecycle defects found by an audit of the previous release.
+
+- A reader killed inside `wasm_heap:lease/1` or `unlease/2` stranded a count
+  nothing could give back, and the object store never collected again.
+- A keeper restart dropped every per-instance memory ceiling, so an instance
+  created with `max_memory_pages` grew past it.
+- A process calling instances it does not destroy kept one table array and one
+  compiled entry per instance, without bound.
+- `sock_send_to` leaked a socket when the send failed, and another when the
+  guest's output pointer was out of bounds.
+- `atomic.wait` reported a wakeup that never happened when the notifier died
+  between claiming a waiter and sending to it.
+- `wasm_engine`'s per-instance limits table had no callers and is gone.
+
 ## 0.1.0
 
 First public release. The versions before it were developed in a private

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -63,6 +63,17 @@ you put each one:
 Use `wasm:compile/1` only for one-shot work; it skips the cache. If you
 instantiate more than once, use `load/1`.
 
+`compile/1` also takes the text format, which is the one-shot case by
+construction:
+
+```erlang
+{ok, Mod} = wasm:compile({wat, ~"(module (func (export \"f\") (result i32) i32.const 7))"}).
+```
+
+`load/1` takes bytes only. The cache is keyed on a content hash and a module
+built from text takes a fresh identity every time it is validated, so there
+would be nothing stable to key on.
+
 ## Know who owns the instance
 
 An instance belongs to the process that created it, like a port or an ETS table:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,27 @@ validates the bytes and caches the result by content hash, so loading the same
 file again costs microseconds instead of milliseconds. Each `instantiate/2`
 gives you a fresh instance that shares nothing with the others.
 
+## Write the module inline
+
+You do not need a `.wasm` file to try something. The runtime reads the text
+format itself, with no toolchain involved:
+
+```erlang
+Src = ~"""
+(module
+  (func (export "add") (param i32 i32) (result i32)
+    local.get 0 local.get 1 i32.add))
+""",
+{ok, Mod}  = wasm:compile({wat, Src}),
+{ok, Inst} = wasm:instantiate(Mod, #{}),
+{ok, [7]}  = wasm:call(Inst, ~"add", [3, 4]).
+```
+
+Use it for a snippet, a test, or a shell session. `compile/1` skips the cache,
+which is right for text: a module built from text takes a fresh identity every
+time, so there is nothing stable to cache it against. Use `load_file/1` for a
+module you instantiate repeatedly.
+
 ## Give it something to call
 
 Imports are plain Erlang functions. Key them by the module and field name the

--- a/src/wasm.app.src
+++ b/src/wasm.app.src
@@ -4,7 +4,7 @@
     %% `wasm' on hex.pm is not ours. Depend on it as
     %% {deps, [{wasm, {pkg, erlang_wasm}}]}.
     {pkg_name, erlang_wasm},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, [wasm_sup, wasm_engine, wasm_module_cache]},
     {mod, {wasm_app, []}},
     {applications, [kernel, stdlib, crypto]},

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -58,12 +58,14 @@ context to diagnose it.
 -export([read_memory/3, write_memory/3, memory_size/1]).
 -export([format_error/1]).
 
--export_type([module_/0, instance/0]).
+-export_type([module_/0, instance/0, source/0]).
 
 -doc "A module: compiled inline, or a handle to a cached one.".
 -nominal module_() :: #module{} | wasm_module_cache:handle().
 -doc "An instance, owned by the process that created it.".
 -nominal instance() :: #inst{}.
+-doc "What `compile/1` takes: the binary format, or the text format.".
+-nominal source() :: binary() | {wat, binary()}.
 
 %%% ------------------------------------------------------------- lifecycle ---
 
@@ -101,12 +103,21 @@ unload({wasm_module, _} = Handle) -> wasm_module_cache:unload(Handle);
 unload(#module{}) -> ok.       % compiled inline; nothing cached to release
 
 -doc """
-Decode and validate a module binary without caching it.
+Decode and validate a module without caching it.
+
+Takes the binary format, or `{wat, Source}` for the text format:
+
+```erlang
+{ok, M} = wasm:compile({wat, ~"(module (func (export \"f\") (result i32) i32.const 7))"}).
+```
 
 Use it for one-shot work. If you instantiate more than once, use `load/1`.
+Text is one-shot by construction: the cache is keyed on a content hash of the
+bytes, and a module built from text takes a fresh identity every time it is
+validated, so `load/1` takes the binary format only.
 """.
--spec compile(binary()) -> {ok, module_()} | {error, wasm_error:error()}.
-compile(Bin) -> compile(Bin, #{}).
+-spec compile(source()) -> {ok, module_()} | {error, wasm_error:error()}.
+compile(Src) -> compile(Src, #{}).
 
 -doc """
 As `compile/1`, with an `identity` for the module.
@@ -118,11 +129,17 @@ one the module gets a fresh reference, which is correct and simply does not
 share. Nothing hashes on this path: five milliseconds on the 1.8 MB QuickJS
 module is not worth paying to buy sharing the inline API does not promise.
 """.
--spec compile(binary(), map()) -> {ok, module_()} | {error, wasm_error:error()}.
-compile(Bin, Opts) ->
+-spec compile(source(), map()) -> {ok, module_()} | {error, wasm_error:error()}.
+compile({wat, Source}, Opts) -> compile_with(Source, Opts, fun wasm_wat:module/1);
+compile(Bin, Opts) -> compile_with(Bin, Opts, fun wasm_decode:module/1).
+
+%% Both front ends answer a `#module{}` or an error value -- `wasm_wat:module/1`
+%% through `wasm_error:capture/1` -- so validation and the identity are the same
+%% two lines either way and neither path raises.
+compile_with(Src, Opts, Front) ->
     Identity = maps:get(identity, Opts, undefined),
-    with_room(byte_size(Bin), fun() ->
-        case wasm_decode:module(Bin) of
+    with_room(byte_size(Src), fun() ->
+        case Front(Src) of
             {error, _} = E -> E;
             {ok, M} -> wasm_validate:module(M#module{identity = Identity})
         end

--- a/test/wasm_wat_SUITE.erl
+++ b/test/wasm_wat_SUITE.erl
@@ -15,6 +15,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include_lib("wasm/include/wasm.hrl").
 
 all() ->
     [parses_what_the_decoder_parses,
@@ -22,7 +23,9 @@ all() ->
      float_literals_round_once,
      refuses_what_the_format_forbids,
      an_unknown_instruction_does_not_become_an_atom,
-     errors_carry_an_offset].
+     errors_carry_an_offset,
+     the_facade_compiles_text_too,
+     the_facade_answers_a_value_for_bad_text].
 
 %% Only the differential cases need `wasm-tools`, so only they skip without one.
 init_per_testcase(Case, Config)
@@ -408,3 +411,34 @@ errors_carry_an_offset(_Config) ->
     {error, #{ctx := #{offset := Off}}} =
         wasm_wat:module(~"(module (memory 1)"),
     ?assertEqual(0, Off).
+
+%% `wasm:compile/1` takes the text format, so an embedder writing a module
+%% inline does not have to know that parsing and validating are two calls.
+%% It has to be the *same* module the two calls produce, or the convenience
+%% would be a second way to build one.
+the_facade_compiles_text_too(_Config) ->
+    Src = ~"""
+    (module
+      (memory (export "mem") 1)
+      (global $g (mut i32) (i32.const 3))
+      (func (export "f") (param i32) (result i32)
+        local.get 0 global.get $g i32.add))
+    """,
+    {ok, Parsed} = wasm_wat:module(Src),
+    {ok, Want} = wasm_validate:module(Parsed),
+    {ok, M} = wasm:compile({wat, Src}),
+    %% Everything but the identity, which is a fresh reference per build and is
+    %% meant to be: text has nothing stable to key a cache on.
+    ?assertEqual(Want#module{identity = undefined}, M#module{identity = undefined}),
+    %% And it instantiates, which is the point of having it.
+    {ok, I} = wasm:instantiate(M, #{}),
+    ?assertEqual({ok, [7]}, wasm:call(I, ~"f", [4])),
+    ok = wasm:destroy(I).
+
+%% Nothing raises. The text front end already answers a value through
+%% `wasm_error:capture/1'; this is that the facade does not lose it.
+the_facade_answers_a_value_for_bad_text(_Config) ->
+    ?assertMatch({error, #{class := _, kind := _, ctx := #{offset := _}}},
+                 wasm:compile({wat, ~"(module (memory 1)"})),
+    ?assertMatch({error, #{class := _, kind := _}},
+                 wasm:compile({wat, ~"(module (global i32 (i32.no_such_thing 1)))"})).


### PR DESCRIPTION
`wasm:compile({wat, Source})` parses and validates in one call. `load/1` is
unchanged and still takes bytes only: the cache is keyed on a content hash, and
a module built from text takes a fresh identity every time.

0.1.1 also carries the seven lifecycle fixes already on `main`.