### PR TITLE
Silence the documentation build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all compile check test ct lint xref dialyzer docs bench suites clean
+.PHONY: all compile check test ct lint xref dialyzer docs publish bench suites clean
 
 all: compile
 
@@ -24,6 +24,9 @@ dialyzer:
 
 docs:
 	rebar3 ex_doc
+
+publish:
+	rebar3 hex publish
 
 # The benchmark arms the performance record in `test/audit/PERF.md' cites.
 # `realbench' is the one a speed claim comes from; read

--- a/rebar.config
+++ b/rebar.config
@@ -52,12 +52,24 @@
 {hex, [{doc, ex_doc}]}.
 
 %% `output' is what rebar3_ex_doc passes to ex_doc; `dir' is where rebar3_hex
-%% looks for the result afterwards. They have to agree, and rebar3_ex_doc warns
-%% that it does not know `dir', which is expected: it is not its option.
+%% looks for the result afterwards. They have to agree.
+%%
+%% **`rebar3 ex_doc' warns `unknown ex_doc option {dir,"_build/doc"}' and that
+%% is expected.** `dir' is not rebar3_ex_doc's option: it is read by
+%% `rebar3_hex_build:resolve_dir/2', which defaults to `doc' and is the only
+%% way to tell it the site is somewhere else. rebar3_ex_doc knows `output' and
+%% nothing else that means the same thing, so one of the two plugins is always
+%% looking at a key the other does not recognise. The alternatives are worse:
+%% write the site to `doc/' instead, or split the release into `rebar3 ex_doc'
+%% followed by `rebar3 hex publish --doc-dir _build/doc', where a plain
+%% `hex publish' would look in `doc/', find nothing and fail.
+%%
+%% There was a `name' here too, and nothing read it: the rendered title comes
+%% from the OTP application, so the docs say `wasm', and the package name
+%% rebar3_hex publishes under comes from `pkg_name' in `wasm.app.src'.
 {ex_doc, [
     {output, "_build/doc"},
     {dir, "_build/doc"},
-    {name, <<"erlang_wasm">>},
     {source_url, <<"https://github.com/benoitc/erlang_wasm">>},
     {main, <<"readme">>},
     {extras, [

--- a/rebar.config
+++ b/rebar.config
@@ -51,25 +51,16 @@
 %% `rebar3 hex publish' stops and asks for one.
 {hex, [{doc, ex_doc}]}.
 
-%% `output' is what rebar3_ex_doc passes to ex_doc; `dir' is where rebar3_hex
-%% looks for the result afterwards. They have to agree.
-%%
-%% **`rebar3 ex_doc' warns `unknown ex_doc option {dir,"_build/doc"}' and that
-%% is expected.** `dir' is not rebar3_ex_doc's option: it is read by
-%% `rebar3_hex_build:resolve_dir/2', which defaults to `doc' and is the only
-%% way to tell it the site is somewhere else. rebar3_ex_doc knows `output' and
-%% nothing else that means the same thing, so one of the two plugins is always
-%% looking at a key the other does not recognise. The alternatives are worse:
-%% write the site to `doc/' instead, or split the release into `rebar3 ex_doc'
-%% followed by `rebar3 hex publish --doc-dir _build/doc', where a plain
-%% `hex publish' would look in `doc/', find nothing and fail.
+%% No `output' and no `dir': the site goes to `doc/', which is both
+%% rebar3_ex_doc's default and where `rebar3_hex_build:resolve_dir/2' looks for
+%% it. Naming either one means naming the other, and neither plugin knows the
+%% other's key, so one of them warns about it on every docs build. `doc/' is
+%% gitignored; the sources are in `docs/'.
 %%
 %% There was a `name' here too, and nothing read it: the rendered title comes
 %% from the OTP application, so the docs say `wasm', and the package name
 %% rebar3_hex publishes under comes from `pkg_name' in `wasm.app.src'.
 {ex_doc, [
-    {output, "_build/doc"},
-    {dir, "_build/doc"},
     {source_url, <<"https://github.com/benoitc/erlang_wasm">>},
     {main, <<"readme">>},
     {extras, [

--- a/src/wasi_net.erl
+++ b/src/wasi_net.erl
@@ -54,7 +54,8 @@ you mean. See `docs/security.md`.
 -export([grant/1, allows/3, bindable/1, resolves/1, max_sockets/1, timeout/1]).
 -export([normalise/1, parse/1]).
 
--export_type([grant/0, endpoint/0, kind/0]).
+%% `rule/0` because `grant/0` is made of them.
+-export_type([grant/0, endpoint/0, kind/0, rule/0]).
 
 %% A cap on descriptors, for the reason the node page budget exists: without
 %% one, a module opens sockets until the node runs out of them.

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -59,6 +59,13 @@ context to diagnose it.
 -export([format_error/1]).
 
 -export_type([module_/0, instance/0, source/0]).
+%% `module_()` is a `#module{}`, so everything its fields are typed with is part
+%% of what a reader of that type needs. They are declared in `include/wasm.hrl`
+%% and exported here, which is also what stops the documentation build reporting
+%% each of them as a reference to something private.
+-export_type([typeidx/0, funcidx/0, tableidx/0, memidx/0,
+              valtype/0, reftype/0, heaptype/0, numtype/0, vectype/0,
+              mut/0, externtype/0, instr/0, annotated/0]).
 
 -doc "A module: compiled inline, or a handle to a cached one.".
 -nominal module_() :: #module{} | wasm_module_cache:handle().

--- a/src/wasm_core.erl
+++ b/src/wasm_core.erl
@@ -29,9 +29,9 @@ Rust plugin and over QuickJS:
 **Arity is not the constraint it looks like.** The worst function in QuickJS
 would generate a 71-argument continuation against the BEAM's limit of 255, so
 `?MAX_ARITY` costs no coverage at all and exists to refuse the pathological
-rather than to shape the common case. The decoder admits a million locals
-(`\wasm_decode:expand_locals/1`) and that is what a bound has to survive, not
-what it has to accommodate.
+rather than to shape the common case. The decoder admits a million locals, which
+`wasm_decode` expands, and that is what a bound has to survive rather than what
+it has to accommodate.
 
 **Frame names are bounded by nesting, not by count.** A function with 1016
 control frames needs far fewer than 1016 names, because Core `letrec` scoping

--- a/src/wasm_instance.erl
+++ b/src/wasm_instance.erl
@@ -1395,9 +1395,9 @@ remember(#inst{id = Id} = Inst) ->
 -doc """
 Note the compiled entry this process has cached for an instance.
 
-`wasm_jit:cached_entry/3` keys it by a bare `reference()` the instance record
-carries, which is what makes a hit one `get/1` with no tuple to build, and also
-what stops anything else recognising the entry as belonging to an instance. So
+`wasm_jit` keys it by a bare `reference()` the instance record carries, which
+is what makes a hit one dictionary read with no tuple to build, and also what
+stops anything else recognising the entry as belonging to an instance. So
 the sweep could not reach it and `release/1` only ever ran in the process that
 destroyed the instance: a worker calling instances somebody else destroys kept
 one closure for each of them, for as long as it lived.

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -2,7 +2,7 @@
 -moduledoc """
 When a module gets compiled, and how a call reaches the result.
 
-You get here from `\wasm:invoke_at/6`. Everything in this module is a policy
+You get here from `wasm`, on the path an invocation takes. Everything here is a policy
 decision on top of two mechanisms that already exist: `wasm_core` generates and
 compiles, and `wasm_code_slots` decides which module name the result may be
 loaded into and when that name may be reused.
@@ -209,8 +209,8 @@ of the node. `wasm_code_slots`'s moduledoc describes exactly this shape as the
 usage it expects and nothing called it.
 
 Idempotent, because `destroy/1` is: releasing a lease that is not there is a
-no-op in `wasm_code_slots:drop/3`, which is the same property that makes a
-double release of a memory harmless.
+no-op in `wasm_code_slots`, which is the same property that makes a double
+release of a memory harmless.
 """.
 -spec release(#inst{}) -> ok.
 release(Inst) ->

--- a/src/wasm_wat_lex.erl
+++ b/src/wasm_wat_lex.erl
@@ -40,7 +40,8 @@ so a parse error can say where rather than what.
 
 -export([tokens/1, scan_all/1]).
 
--export_type([token/0]).
+%% `pos/0` because every `token/0` carries one.
+-export_type([token/0, pos/0]).
 
 -doc "A token and the byte offset it starts at.".
 -nominal token() :: {lparen, pos()}


### PR DESCRIPTION
Sixty-nine ex_doc warnings, down to one.

The types `#module{}` is built from were private, so every reference to
`wasm:module_()` reported one. Four doc comments linked to private functions.

The one left is `unknown ex_doc option {dir,...}`: rebar3_hex reads it,
rebar3_ex_doc does not, and there is no spelling both know. rebar.config says
so and names the alternatives.