### PR TITLE
Split the supervision tree, and fix three defects a stress run found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+The supervision tree is one supervisor per subsystem. Five servers under one
+`intensity => 5, period => 10` shared a budget, so losing the module cache
+repeatedly could take the engine, the keeper and the code slots with it, and
+the tables went too. Each subsystem now has its own supervisor and its own
+`10 in 60`, and `wasm_store` owns the long-lived tables.
+
+A wrong-typed call argument answers `{link, argument_type}` where it used to
+answer `{malformed, internal}`. `malformed` is the decode class and an argument
+is not a decode concern; the kind is new, the class has changed, and anything
+matching on the old pair needs updating.
+
+### Fixed
+
+- **`atomic.fence` was rejected as invalid.** The decoder and the interpreter
+  both knew it and the validator had no clause, so every module carrying a
+  fence failed to load. The specification suite does not exercise it.
+- **A tree death leaked the node page budget permanently.** The counter lives
+  in `persistent_term` and outlives the supervision tree; the registry that
+  says who holds those pages does not. Pages charged when the tree died could
+  never be released, and it accumulated across application restarts.
+  `wasm_keeper` now reconciles the two when it starts.
+- **A limits map that could not mean what it said was ignored.**
+  `#{max_depth => lots}` failed open, because every integer sorts before every
+  atom, so a guest could recurse a million frames under a ceiling the embedder
+  believed it had set. `wasm_limits:validate/1` existed and nothing called it.
+- **The compiled tier computed on ill-typed arguments.** `wasm_exec` checks
+  arity and the tier never reaches it, so the same call answered differently
+  depending on whether the function was hot; and a float passed for an `i32`
+  was rejected by the interpreter and had `i32.add` run on it by the tier.
+  Both are checked once now, before either engine is chosen.
+
 ## 0.1.1
 
 `wasm:compile/1` takes the text format:

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -65,6 +65,17 @@ globals that are not shared cells, direct and indirect calls, bulk memory
 set, and the whole SIMD set. Not exceptions, not the GC types, and not
 memory64.
 
+**Exporting a mutable global costs you every function that reads it.** An
+exported mutable global becomes a reference cell rather than a value, and a
+function reading one is refused with `{unsupported, global_get_ref}`. That is
+the "globals that are not shared cells" clause above, and it is easy to trip
+without noticing, because nothing about the module looks different and the
+interpreter answers correctly either way. It is worth checking against
+`subset.erl` if your eligible-function count is lower than the instruction list
+above suggests: on a corpus of generated modules that exported everything, it
+took 121 eligible functions to none, and removing only the global exports put
+all 121 back.
+
 **Only the functions your workload actually ran are compiled**, which for
 QuickJS is 223 of 1666 and about 23 seconds of a core in the background. A
 function left out is interpreted and can still call back into compiled code.

--- a/rebar.config
+++ b/rebar.config
@@ -113,7 +113,7 @@
                            wasm_wat, wasm_wat_lex, wasm_wat_sexp,
                            wasm_wat_num, wasm_wat_instr, wasm_wast]},
         {<<"Numerics">>, [wasm_num, wasm_num_float, wasm_num_trunc, wasm_simd]},
-        {<<"Supervision">>, [wasm_app, wasm_sup]}
+        {<<"Supervision">>, [wasm_app, wasm_sup, wasm_subsup, wasm_store]}
     ]},
     {api_reference, true}
 ]}.

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -250,6 +250,57 @@ instantiate(#module{} = M, Imports, Opts0) ->
 %% every atom, so the test was never true and a guest could recurse a million
 %% frames under a limit the embedder thought they had set. It failed open, which
 %% is the one direction a limit must not fail.
+%% Arguments are checked here, at the one boundary both engines are behind.
+%%
+%% `wasm_exec:check_arity/2` guards the interpreter and the compiled tier never
+%% reaches it: `wasm_jit` enters the generated module directly. So the same
+%% mistake answered `{link, argument_arity}` interpreted and `{malformed,
+%% internal}` compiled, and which one an embedder saw depended on whether the
+%% function happened to be hot yet.
+%%
+%% Types were not checked on either path. The interpreter blew up on a float
+%% where an i32 belonged and the error value was a captured crash; the compiled
+%% tier ran `i32.add` on the float and answered `{ok, [-2.5]}`, a wrong-typed
+%% result with nothing to say it was wrong. Checking once here makes the two
+%% agree by construction rather than by keeping two checks in step.
+check_args(Inst, Name, Args) ->
+    case wasm_instance:params_of(Inst, Name) of
+        undefined ->
+            ok;
+        Params when length(Params) =/= length(Args) ->
+            {error, err(link, argument_arity, ~"wrong number of arguments",
+                        #{expected => length(Params), got => length(Args)})};
+        Params ->
+            check_arg_types(Params, Args, 0)
+    end.
+
+%% Numbers and vectors only.
+%%
+%% Those are the types the engines disagreed about, because they are the ones
+%% generated code computes on: an `i32.add` handed a float answered with a
+%% float. A reference is an opaque term with several shapes -- `{objref, N}` for
+%% a struct or array, a funcref carrying its defining instance, `null` -- and
+%% both engines pass them through the same way, so a partial predicate over them
+%% would reject working programs to no purpose. `wasm_instance:value_matches/2`
+%% is written for imported globals and is exactly that partial predicate; the
+%% first version of this used it for every parameter and refused every GC
+%% reference the collection suite passes.
+check_arg_types([], [], _N) ->
+    ok;
+check_arg_types([T | Ts], [A | As], N) when T =:= i32; T =:= i64;
+                                            T =:= f32; T =:= f64;
+                                            T =:= v128 ->
+    case wasm_instance:value_matches(T, A) of
+        true ->
+            check_arg_types(Ts, As, N + 1);
+        false ->
+            {error, err(link, argument_type,
+                        ~"argument is not a value of the declared type",
+                        #{index => N, expected => T, got => A})}
+    end;
+check_arg_types([_Ref | Ts], [_A | As], N) ->
+    check_arg_types(Ts, As, N + 1).
+
 check_limits(Opts) ->
     case wasm_limits:validate(Opts) of
         ok ->
@@ -351,7 +402,11 @@ call(Inst, Name, Args, Opts) ->
 
 call_1(Inst, Name, Args, Opts) ->
     case wasm_instance:export_kind(Inst, Name) of
-        {ok, {func, Idx}} -> invoke(Inst, Idx, Args, Opts);
+        {ok, {func, Idx}} ->
+            case check_args(Inst, Name, Args) of
+                {error, _} = E -> E;
+                ok -> invoke(Inst, Idx, Args, Opts)
+            end;
         {ok, Other} ->
             {error, err(link, not_a_function, <<"export is not a function">>,
                         #{name => Name, kind => Other})};

--- a/src/wasm.erl
+++ b/src/wasm.erl
@@ -232,10 +232,32 @@ instantiate(#module{} = M, Imports, Opts0) ->
         {error, _} = E ->
             E;
         {ok, Opts} ->
-            case wasm_instance:new(M, Imports, Opts) of
+            case check_limits(Opts) of
                 {error, _} = E -> E;
-                {ok, Inst} -> run_start(M, Inst, Opts)
+                ok ->
+                    case wasm_instance:new(M, Imports, Opts) of
+                        {error, _} = E -> E;
+                        {ok, Inst} -> run_start(M, Inst, Opts)
+                    end
             end
+    end.
+
+%% A limits map that cannot mean what it says is refused rather than ignored.
+%%
+%% `wasm_limits:validate/1` has always been able to answer this and nothing
+%% called it, so a bad value was simply not enforced. `#{max_depth => lots}` was
+%% the sharp one: the guard is `Depth >= MaxDepth`, every integer sorts before
+%% every atom, so the test was never true and a guest could recurse a million
+%% frames under a limit the embedder thought they had set. It failed open, which
+%% is the one direction a limit must not fail.
+check_limits(Opts) ->
+    case wasm_limits:validate(Opts) of
+        ok ->
+            ok;
+        {error, {invalid_limits, Bad}} ->
+            {error, err(link, invalid_limits,
+                        ~"limit is not a value that limit can take",
+                        #{keys => Bad})}
     end.
 
 %% `profile` names a workload; everything it sets is an option you could have
@@ -311,11 +333,23 @@ abandoned(Err, _Inst) ->
 
 -spec call(instance(), binary(), [term()]) ->
           {ok, [term()]} | {error, wasm_error:error()}.
-call(Inst, Name, Args) -> call(Inst, Name, Args, #{}).
+call(Inst, Name, Args) -> call_1(Inst, Name, Args, #{}).
 
 -spec call(instance(), binary(), [term()], map()) ->
           {ok, [term()]} | {error, wasm_error:error()}.
+%% Per-call limits are checked here and not in `invoke_at/6`, which nested and
+%% re-entrant calls also reach. An empty map is the common case -- `call/3` is
+%% this with `#{}` -- so the check is a clause head rather than work on the path
+%% every QuickJS call takes.
+call(Inst, Name, Args, Opts) when map_size(Opts) =:= 0 ->
+    call_1(Inst, Name, Args, Opts);
 call(Inst, Name, Args, Opts) ->
+    case check_limits(Opts) of
+        {error, _} = E -> E;
+        ok -> call_1(Inst, Name, Args, Opts)
+    end.
+
+call_1(Inst, Name, Args, Opts) ->
     case wasm_instance:export_kind(Inst, Name) of
         {ok, {func, Idx}} -> invoke(Inst, Idx, Args, Opts);
         {ok, Other} ->

--- a/src/wasm_app.erl
+++ b/src/wasm_app.erl
@@ -3,13 +3,16 @@
 Application callback.
 
 Start the application before you load or instantiate anything: it owns the
-module cache and the node page budget. The supervision tree is deliberately
-shallow at this stage. Milestones M0-M4
-cover decoding, validation, execution and linear memory, none of which owns
-long-lived mutable state outside a caller's process. `wasm_engine` exists
-from the start only because node-wide page accounting must be in place
-before linear memory can grow (M4): `atomics` pages are off-heap and
-invisible to `max_heap_size`, so nothing else would bound them.
+module cache and the node page budget.
+
+The tree is one supervisor per subsystem, so a restart budget is shared only by
+things that belong together; `wasm_sup` draws it. It was flat until a stress run
+showed what that costs: five servers under one `intensity => 5, period => 10`
+meant losing the module cache repeatedly could take the engine and the keeper
+with it, and the tables went too. `wasm_engine` still starts before anything
+that allocates, because node-wide page accounting must be in place before linear
+memory can grow: `atomics` pages are off-heap and invisible to `max_heap_size`,
+so nothing else would bound them.
 """.
 -behaviour(application).
 

--- a/src/wasm_engine.erl
+++ b/src/wasm_engine.erl
@@ -30,6 +30,7 @@ eventually refuses every allocation on the node.
 -export([start_link/0]).
 -export([table_grow_limit/0]).
 -export([reserve_pages/1, release_pages/1, pages_in_use/0, page_limit/0,
+         set_pages_in_use/1,
          set_page_limit/1, stats/0]).
 -export([table_put/2, table_get/1, table_forget/1]).
 -export([cell_put/2, cell_get/1, cell_forget/1]).
@@ -113,6 +114,24 @@ release_pages(N) when is_integer(N), N > 0 ->
 
 -spec pages_in_use() -> non_neg_integer().
 pages_in_use() -> atomics:get(counters_ref(), ?SLOT_PAGES).
+
+-doc """
+Set the page count outright, for `wasm_keeper` reconciliation and nothing else.
+
+The counter lives in `persistent_term` and so outlives the supervision tree; the
+registry that says who holds those pages is a table that does not. If the tree
+goes, the count survives with nobody left to give any of it back, and every page
+charged at that moment is gone for the life of the node. `wasm_keeper` puts the
+two back in step when it starts, which it can do safely because every
+`reserve_pages/1` and `release_pages/1` call in the runtime goes through that
+process.
+
+Call it from anywhere else and the node's accounting becomes a number somebody
+chose rather than a sum of what is held.
+""".
+-spec set_pages_in_use(non_neg_integer()) -> ok.
+set_pages_in_use(N) when is_integer(N), N >= 0 ->
+    atomics:put(counters_ref(), ?SLOT_PAGES, N).
 
 -spec page_limit() -> non_neg_integer().
 page_limit() -> atomics:get(counters_ref(), ?SLOT_LIMIT).

--- a/src/wasm_instance.erl
+++ b/src/wasm_instance.erl
@@ -30,6 +30,7 @@ what you use of it rather than what it contains.
 -include("wasm_exec.hrl").
 
 -export([new/2, new/3, exports/1, export_kind/2, func_type/2, global_type/2]).
+-export([params_of/2, value_matches/2]).
 -export([tag/2, default_value/1]).
 -export([mut/1, set_mut/2, memory/2, heap/1]).
 -export([root_view/1, mut_of/1, elems_of/1, release/1]).
@@ -822,8 +823,14 @@ heap_subtype({type, _}, func) -> true;
 heap_subtype(_, _) -> false.
 
 
-%% The embedder hands over a bare Erlang term for a global, so the check is on
-%% the value's shape rather than on a declared type it does not carry.
+-doc """
+Does this Erlang term satisfy that WebAssembly value type?
+
+The embedder hands over a bare term, for an imported global or for a call
+argument, so the check is on the value's shape rather than on a declared type it
+does not carry.
+""".
+-spec value_matches(term(), term()) -> boolean().
 value_matches(i32, V) -> is_integer(V);
 value_matches(i64, V) -> is_integer(V);
 value_matches(f32, V) -> is_float(V) orelse is_float_special(V);
@@ -1234,6 +1241,22 @@ func_type(#inst{exports = E, funcs = Fs}, Name) ->
                 #hostfn{type = T} -> T
             end;
         _ -> undefined
+    end.
+
+-doc """
+The parameter types of an exported function, or `undefined`.
+
+`func_type/2` answers what the function carries, which is a canonical id, its
+supertypes and the `#functype{}`. A caller checking arguments wants only the
+last part, and unwrapping it at each call site is how the two shapes get
+confused.
+""".
+-spec params_of(#inst{}, binary()) -> [valtype()] | undefined.
+params_of(Inst, Name) ->
+    case func_type(Inst, Name) of
+        {_Canon, _Supers, #functype{params = P}} -> P;
+        #functype{params = P} -> P;
+        undefined -> undefined
     end.
 
 -spec memory(#inst{}, non_neg_integer()) -> wasm_memory:mem().

--- a/src/wasm_keeper.erl
+++ b/src/wasm_keeper.erl
@@ -359,8 +359,43 @@ init([]) ->
     %% the size before the growth, so that is a specification violation and not
     %% only a leak.
     {Growing, Totals, Caps} = adopt_growths(adopt_totals(), adopt_caps()),
+    ok = reconcile_pages(),
     {ok, #{held => Held, mons => Mons, growing => Growing, queued => #{},
            caps => Caps, totals => Totals}}.
+
+%% Put the node page counter back in step with the registry.
+%%
+%% The counter is an `atomics' array in `persistent_term': it outlives this
+%% process, the supervision tree, and `application:stop(wasm)'. The registry is
+%% a table that does not. When the two part company the counter is the half that
+%% survives, holding a charge for memories whose monitors are gone, so nothing
+%% will ever release them: a killed tree used to cost the node eight megabytes
+%% of budget per thirty-two page instance, permanently, accumulating across
+%% application restarts until only a node restart cleared it.
+%%
+%% The registry is the truth, because it is the only thing that can give pages
+%% back. Doing this here is race-free without any locking: every
+%% `wasm_engine:reserve_pages/1' and `release_pages/1' call in the runtime is
+%% made from this process, and callers block on `gen_server:call' until `init/1'
+%% returns, so no reservation can be in flight while it runs.
+reconcile_pages() ->
+    Charged = ets:foldl(fun({_Res, _Meta, Pages, H}, Acc) when is_map(H) ->
+                                Acc + Pages;
+                           (_Other, Acc) -> Acc
+                        end, 0, ?TAB),
+    %% Per resource row, not per holder: `adopt_totals/0' counts a two-holder
+    %% memory twice on purpose, because it is building per-token totals. The
+    %% node count must not.
+    case wasm_engine:pages_in_use() - Charged of
+        0 ->
+            ok;
+        Orphaned ->
+            ok = wasm_engine:set_pages_in_use(Charged),
+            logger:warning("wasm: page counter held ~p pages no holder claims; "
+                           "reset to ~p to match the registry",
+                           [Orphaned, Charged]),
+            ok
+    end.
 
 %% Rebuilt from the registry on a restart, for the same reason the monitors are.
 adopt_totals() ->

--- a/src/wasm_store.erl
+++ b/src/wasm_store.erl
@@ -1,0 +1,91 @@
+-module(wasm_store).
+-moduledoc """
+Owns every long-lived ETS table, and does nothing else.
+
+The tables outlive the processes that use them. `wasm_keeper`'s registry decides
+whether pages ever come back, `wasm_engine`'s store holds every table's
+contents and every shared global's value, and `wasm_code_slots`' tables say
+which generated module names are in use. A server that created its own would
+take that state down with it on every restart and come back believing the node
+held nothing.
+
+They used to belong to `wasm_sup`, which gave them the right lifetime against a
+*child* crash and the wrong one against anything else: the root supervisor is
+also the process every subsystem hangs off, so it is the process most likely to
+be restarted, and it took the registry with it. This module is the owner
+instead, so the tables survive any subsystem's supervisor being restarted, and
+`wasm_sup` goes back to supervising.
+
+## Why the heir is the supervisor
+
+`wasm_store_sup` is named as each table's heir. It is found by name rather than
+passed in, because a supervisor registers its name before it starts any child,
+so it is already resolvable from here and there is nothing to thread through
+`wasm_sup`'s child specs.
+
+Naming it as heir means this process crashing hands the tables over rather than
+destroying them. The supervisor then owns them,
+which is exactly the arrangement that worked before, and the replacement
+`wasm_store` finds them already there: every `ensure_*` function it calls is a
+no-op on an existing table, so it simply leaves them where they are. There is no
+give-away dance and nothing to get wrong on the way back.
+
+The cost is one `"Supervisor received unexpected message"` error report per
+transfer, because an OTP supervisor has no `handle_info` for `ETS-TRANSFER`.
+That is the right trade: this process holds tables and runs no logic, so it does
+not crash on its own, and one noisy report beats losing the node's resource
+accounting.
+
+## What it deliberately does not cover
+
+Nothing inside a supervision tree survives the root of that tree dying. If
+`wasm_sup` goes, the heir goes with it and the tables go too. That case is made
+*harmless* rather than impossible, by `wasm_keeper` reconciling the page counter
+against the registry when it starts: a lost registry then reads as a clean
+reset instead of a permanent leak. See `wasm_keeper:init/1`.
+""".
+-behaviour(gen_server).
+
+-export([start_link/0, tables/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+%% Named rather than derived, because a table this does not know about is one
+%% nothing gives a lifetime to. Adding a long-lived table means adding it here.
+-define(TABLES, [wasm_holders, wasm_tables, wasm_waiters,
+                 wasm_code_slots, wasm_code_calls]).
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc "The tables this owns. For diagnostics and for the architecture suite.".
+-spec tables() -> [atom()].
+tables() -> ?TABLES.
+
+init([]) ->
+    %% Each of these is idempotent and each belongs to the module that reads it,
+    %% so the knowledge of what a table holds stays there and only the lifetime
+    %% is decided here.
+    ok = wasm_keeper:ensure_table(),
+    ok = wasm_engine:ensure_store(),
+    ok = wasm_engine:ensure_waiter_table(),
+    ok = wasm_code_slots:ensure_table(),
+    Heir = whereis(wasm_store_sup),
+    _ = [bequeath(T, Heir) || T <- ?TABLES, is_pid(Heir)],
+    {ok, Heir}.
+
+%% Only a table this process actually created. After a transfer the supervisor
+%% owns them and setting an heir from here would fail, which is the ordinary
+%% case on every restart after the first crash.
+bequeath(Tab, Heir) ->
+    case ets:info(Tab, owner) of
+        Owner when Owner =:= self() ->
+            true = ets:setopts(Tab, {heir, Heir, ?MODULE}),
+            ok;
+        _ ->
+            ok
+    end.
+
+handle_call(_Req, _From, State) -> {reply, {error, unknown_call}, State}.
+handle_cast(_Msg, State) -> {noreply, State}.
+handle_info(_Info, State) -> {noreply, State}.

--- a/src/wasm_subsup.erl
+++ b/src/wasm_subsup.erl
@@ -1,0 +1,76 @@
+-module(wasm_subsup).
+-moduledoc """
+One subsystem of the runtime, with a restart budget of its own.
+
+`wasm_sup` used to supervise all five servers directly, which meant they shared
+one allowance: `intensity 5, period 10` counted restarts across the whole set,
+so losing the module cache three times and the keeper twice inside ten seconds
+took down the engine, the code slots and the application with them. A stress run
+reached exactly that, and the tree it left behind kept answering calls while the
+node's page accounting had quietly reset.
+
+A subsystem is the unit that should share a budget, so each one gets a
+supervisor and the budget lives there. Cache churn can now spend the cache's
+allowance and nothing else's.
+
+## Why one module and not five
+
+The difference between the subsystems is a strategy, a budget and a list of
+children. That is data, and writing it out five times would put the shape of the
+tree in five files instead of in `wasm_sup`, where it is worth reading. Each
+supervisor is registered under its own name, so the tree still reads the way the
+diagram in `wasm_sup` draws it.
+
+```erlang
+wasm_subsup:child(wasm_code_sup, rest_for_one, [wasm_code_slots, wasm_jit_sup])
+```
+""".
+-behaviour(supervisor).
+
+-export([child/3, start_link/3, init/1]).
+
+-doc """
+A child spec for `wasm_sup`: one subsystem, under a supervisor of its own.
+
+`Kids` names the modules to supervise, in start order. Each is started by its
+own `start_link/0` and is `permanent`, because every one of them owns state the
+rest of the runtime reads.
+""".
+-spec child(atom(), supervisor:strategy(), [module()]) ->
+          supervisor:child_spec().
+child(Name, Strategy, Kids) ->
+    #{id => Name,
+      start => {?MODULE, start_link, [Name, Strategy, Kids]},
+      restart => permanent,
+      shutdown => 10000,
+      type => supervisor,
+      modules => [?MODULE | Kids]}.
+
+-spec start_link(atom(), supervisor:strategy(), [module()]) ->
+          supervisor:startlink_ret().
+start_link(Name, Strategy, Kids) ->
+    supervisor:start_link({local, Name}, ?MODULE, {Strategy, Kids}).
+
+init({Strategy, Kids}) ->
+    %% Ten in sixty rather than five in ten. The old numbers were tuned for a
+    %% supervisor holding the whole runtime, where giving up early was the safe
+    %% answer; a supervisor holding one subsystem can afford to keep trying,
+    %% because the blast radius of it failing is now that subsystem alone. A
+    %% subsystem that really cannot start burns ten restarts in a minute and
+    %% then reports upward, which is the signal `wasm_sup` acts on.
+    Flags = #{strategy => Strategy, intensity => 10, period => 60},
+    {ok, {Flags, [spec(K) || K <- Kids]}}.
+
+spec(Mod) ->
+    #{id => Mod,
+      start => {Mod, start_link, []},
+      restart => permanent,
+      shutdown => 5000,
+      type => kind(Mod),
+      modules => [Mod]}.
+
+%% `wasm_jit_sup` is a supervisor and everything else here is a worker. Asked of
+%% the module rather than carried in the child list, because getting it wrong is
+%% a shutdown bug that only shows up on a release upgrade.
+kind(wasm_jit_sup) -> supervisor;
+kind(_) -> worker.

--- a/src/wasm_sup.erl
+++ b/src/wasm_sup.erl
@@ -3,29 +3,60 @@
 Root supervisor. What `application:ensure_all_started(wasm)` gets you:
 
 ```
-wasm_sup
+wasm_sup                one_for_one, 5 in 300
   |
-  +-- wasm_engine          node-wide page budget and shared storage
+  +-- wasm_store_sup    one_for_one    the long-lived ETS tables
+  |     +-- wasm_store
   |
-  +-- wasm_keeper          who still holds each shared resource
+  +-- wasm_engine_sup   one_for_one    node-wide page budget, shared storage
+  |     +-- wasm_engine
   |
-  +-- wasm_code_slots      which generated BEAM module names are in use
+  +-- wasm_keeper_sup   one_for_one    who still holds each shared resource
+  |     +-- wasm_keeper
   |
-  +-- wasm_module_cache    compiled modules, keyed by content hash
+  +-- wasm_code_sup     rest_for_one   generated code and the compilers
+  |     +-- wasm_code_slots
+  |     +-- wasm_jit_sup
+  |
+  +-- wasm_cache_sup    one_for_one    modules, keyed by content hash
+        +-- wasm_module_cache
 ```
 
 There is deliberately no instance supervisor. An instance is owned by the
-process that created it, and applications put instances inside whatever
-process shape suits them; see `docs/worker.md`. `wasm_engine` starts first
-and is `permanent`, because it owns the page budget, so nothing may allocate
-memory before it exists.
+process that created it, and applications put instances inside whatever process
+shape suits them; see `docs/worker.md`.
 
-The supervisor owns the holder registry, the shared store and the waiter table
-rather than letting their users create them. An ETS table dies with the process that
-created it, so a keeper that created its own registry would take every
-resource's accounting down with it on restart and come back believing the node
-held nothing, and an engine that owned the store would take away the rows that
-registry points at.
+## Why a supervisor per subsystem
+
+Because a restart budget is shared by everything under one supervisor, and these
+five have nothing to do with each other. Flat, they shared `5 in 10`: losing the
+module cache three times and the keeper twice inside ten seconds took the engine
+and the code slots down with them, along with the application. That is not
+hypothetical, it is what a stress run did, and what it left behind was worse than
+a stopped application -- see `wasm_keeper:init/1`.
+
+A subsystem is the unit that should share an allowance, so each one has its own
+supervisor and its own `10 in 60`. `wasm_sup` then counts only *subsystems*
+collapsing, and a subsystem collapses only after burning ten restarts in a
+minute, so `5 in 300` here is a genuinely broken node rather than a busy one.
+
+`wasm_code_sup` is `rest_for_one` because `wasm_code_slots` hands out the slots
+the compilers under `wasm_jit_sup` reserve: a slot manager that restarts should
+take the in-flight compilers with it rather than leave them writing into slots
+nobody is tracking. They are `temporary` and `brutal_kill` already, and losing
+one costs only the work.
+
+The rest is `one_for_one`. `wasm_keeper` calls `wasm_engine` for pages, but the
+page counters live in `persistent_term` and the store is a table `wasm_store`
+owns, so an engine restart takes nothing the keeper depends on; making that
+`rest_for_one` would restart the keeper for no gain.
+
+## Why the tables are a subsystem and start first
+
+They used to belong to this process. That gave them the right lifetime against a
+worker crash and the wrong one against everything else, because the root is the
+process every subsystem hangs off. `wasm_store` owns them now, and it starts
+first because nothing may create a table it does not own.
 """.
 -behaviour(supervisor).
 
@@ -35,41 +66,12 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    ok = wasm_keeper:ensure_table(),
-    ok = wasm_engine:ensure_store(),
-    ok = wasm_engine:ensure_waiter_table(),
-    ok = wasm_code_slots:ensure_table(),
-    SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
-    Children = [
-        #{id => wasm_engine,
-          start => {wasm_engine, start_link, []},
-          restart => permanent,
-          shutdown => 5000,
-          type => worker,
-          modules => [wasm_engine]},
-        #{id => wasm_keeper,
-          start => {wasm_keeper, start_link, []},
-          restart => permanent,
-          shutdown => 5000,
-          type => worker,
-          modules => [wasm_keeper]},
-        #{id => wasm_code_slots,
-          start => {wasm_code_slots, start_link, []},
-          restart => permanent,
-          shutdown => 5000,
-          type => worker,
-          modules => [wasm_code_slots]},
-        #{id => wasm_jit_sup,
-          start => {wasm_jit_sup, start_link, []},
-          restart => permanent,
-          shutdown => 5000,
-          type => supervisor,
-          modules => [wasm_jit_sup]},
-        #{id => wasm_module_cache,
-          start => {wasm_module_cache, start_link, []},
-          restart => permanent,
-          shutdown => 5000,
-          type => worker,
-          modules => [wasm_module_cache]}
-    ],
+    SupFlags = #{strategy => one_for_one, intensity => 5, period => 300},
+    Children =
+        [wasm_subsup:child(wasm_store_sup,  one_for_one,  [wasm_store]),
+         wasm_subsup:child(wasm_engine_sup, one_for_one,  [wasm_engine]),
+         wasm_subsup:child(wasm_keeper_sup, one_for_one,  [wasm_keeper]),
+         wasm_subsup:child(wasm_code_sup,   rest_for_one, [wasm_code_slots,
+                                                           wasm_jit_sup]),
+         wasm_subsup:child(wasm_cache_sup,  one_for_one,  [wasm_module_cache])],
     {ok, {SupFlags, Children}}.

--- a/src/wasm_validate_code.erl
+++ b/src/wasm_validate_code.erl
@@ -822,6 +822,18 @@ instr({Op, {Align, Offset, M}}, S0) when is_atom(Op) ->
         Shape -> load_store_instr(Shape, Align, Offset, M, S0)
     end;
 
+%% The one instruction in the `0xFE' space that is a bare atom. It names no
+%% memory, so it never reaches `atomic_instr/5' above, and it needs no memory to
+%% exist: a module with a fence and no memory at all is valid. Takes nothing off
+%% the stack and puts nothing back.
+%%
+%% Missing until a generated module found it. `wasm_decode_atomic' decodes it
+%% and `wasm_exec' runs it, so only this clause was absent, and every module
+%% carrying a fence was rejected `unknown_operator'. The specification suite
+%% cannot catch that: `proposals/threads/atomic.wast' has no `atomic.fence' in
+%% it, so the baseline had nothing to fail on.
+instr(atomic_fence, S) -> S;
+
 %% - numeric ---------------------------------------------------------------
 instr(Op, S0) when is_atom(Op) ->
     case numeric(Op) of

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -2860,3 +2860,38 @@ is reached; and `wasm_jit:counts/0` reports `entered => 3` for the whole run,
 so `cached_entry/3` runs three times against 30,000 JavaScript iterations.
 
 Worth re-running on a quiet box before the next performance claim leans on it.
+
+## The stress run's fixes, held against QuickJS
+
+Two of these touch code every embedder call passes through: `wasm:call/4` now
+checks the limits map when it is not empty, and `call_1/4` checks argument arity
+and types before either engine is chosen. Neither is per-instruction, but this
+project has had three changes near the dispatch path cost about 70% while the
+synthetic loop measured nothing, so the protocol applies whatever the shape of
+the change.
+
+Five interleaved pairs on `qjs.wasm` against `f8d4f13`, minimum of three runs
+per launch, orderings alternated. Load average 10.4 to 10.9 throughout, which is
+below the 12 to 14 the rest of this file was taken at.
+
+| pair | order | base | branch |
+| ---: | --- | ---: | ---: |
+| 1 | base first | 1679.3 ms | 1843.2 ms |
+| 2 | **branch first** | 1672.9 ms | 1717.1 ms |
+| 3 | base first | 1653.8 ms | 1659.8 ms |
+| 4 | **branch first** | 2760.5 ms | 1692.8 ms |
+| 5 | base first | 1694.2 ms | 1660.7 ms |
+
+Minimums: base 1653.8 ms, branch 1659.8 ms, a difference of 0.36%.
+
+**This establishes no large regression, not no regression.** The base arm's own
+spread across the five launches is 1653.8 to 2760.5 ms, which is sixty-seven
+per cent, and the difference being measured is well inside it. Pair 4's base is
+plainly an outlier; the ordering does not explain the rest, since the branch
+wins one base-first pair and loses one branch-first pair.
+
+The mechanism agrees. `wasm:call/3` reaches the limits check as a clause head on
+an empty map and does no work, and the argument check runs once per embedder
+call: this workload makes one, then runs 30,000 JavaScript iterations inside it.
+
+Worth re-running on a quiet box before any claim leans on the 0.36%.

--- a/test/wasm_budget_SUITE.erl
+++ b/test/wasm_budget_SUITE.erl
@@ -21,7 +21,8 @@ directly, and every limit has to see it that way.
          growth_past_the_ceiling_returns_minus_one/1,
          an_imported_memory_counts_against_the_ceiling/1,
          the_strictest_holder_bounds_a_shared_memory/1,
-         two_slots_on_one_memory_count_once/1]).
+         two_slots_on_one_memory_count_once/1,
+         a_limit_that_is_not_a_number_is_refused/1]).
 
 all() ->
     [an_import_called_in_a_loop_is_stopped,
@@ -33,7 +34,8 @@ all() ->
      growth_past_the_ceiling_returns_minus_one,
      an_imported_memory_counts_against_the_ceiling,
      the_strictest_holder_bounds_a_shared_memory,
-     two_slots_on_one_memory_count_once].
+     two_slots_on_one_memory_count_once,
+     a_limit_that_is_not_a_number_is_refused].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(wasm),
@@ -241,3 +243,40 @@ drain(Tag, N) ->
     receive Tag -> drain(Tag, N + 1)
     after 0 -> N
     end.
+
+%% A limit that cannot mean what it says is refused, not ignored.
+%%
+%% `wasm_limits:validate/1` could always answer this and nothing called it, so a
+%% bad value was simply not enforced. `#{max_depth => lots}` is the sharp one
+%% and it failed *open*: the guard is `Depth >= MaxDepth`, every integer sorts
+%% before every atom in Erlang term order, so the test was never true and a
+%% guest recursed a million frames under a ceiling the embedder believed it had
+%% set. Every other bad value already failed closed, which is what made this one
+%% easy to miss.
+a_limit_that_is_not_a_number_is_refused(_Config) ->
+    Mod = recursive(),
+    Bad = [{max_depth, lots}, {fuel, lots}, {max_memory_pages, -1},
+           {max_depth, 0}, {max_heap_words, 0}],
+    [?assertMatch({error, #{class := link, kind := invalid_limits,
+                            ctx := #{keys := [K]}}},
+                  wasm:instantiate(Mod, #{}, #{K => V}))
+     || {K, V} <- Bad],
+    %% And per call, where a limits map also lands.
+    {ok, Inst} = wasm:instantiate(Mod, #{}, #{}),
+    ?assertMatch({error, #{class := link, kind := invalid_limits}},
+                 wasm:call(Inst, ~"r", [10], #{max_depth => lots})),
+    %% The limit that used to vanish now bites, and a valid one still works.
+    ?assertMatch({error, #{class := exhaustion, kind := call_stack_exhausted}},
+                 wasm:call(Inst, ~"r", [100000], #{max_depth => 64})),
+    ?assertEqual({ok, [0]}, wasm:call(Inst, ~"r", [10])),
+    ok = wasm:destroy(Inst).
+
+recursive() ->
+    {ok, M} = wasm:compile({wat, ~"""
+    (module
+      (func $r (export "r") (param i32) (result i32)
+        (if (result i32) (i32.eqz (local.get 0))
+          (then (i32.const 0))
+          (else (call $r (i32.sub (local.get 0) (i32.const 1)))))))
+    """}),
+    M.

--- a/test/wasm_jit_lifetime_SUITE.erl
+++ b/test/wasm_jit_lifetime_SUITE.erl
@@ -212,9 +212,15 @@ the_compiler_is_supervised(_) ->
     %% A process nothing can see is a process nothing can stop, bound or count.
     %% Compiling used to be a bare `spawn/1`: invisible to the tree, outliving
     %% `application:stop(wasm)`, and unbounded.
-    Children = supervisor:which_children(wasm_sup),
+    %% Under `wasm_code_sup` rather than the root: the slot manager and the
+    %% compilers that reserve slots from it share one subsystem, and one
+    %% restart budget, on purpose. See `wasm_sup`.
+    ?assertMatch({wasm_code_sup, _, supervisor, _},
+                 lists:keyfind(wasm_code_sup, 1,
+                               supervisor:which_children(wasm_sup))),
     ?assertMatch({wasm_jit_sup, _, supervisor, _},
-                 lists:keyfind(wasm_jit_sup, 1, Children)),
+                 lists:keyfind(wasm_jit_sup, 1,
+                               supervisor:which_children(wasm_code_sup))),
     %% Started empty and told what to compile afterwards, so the instance is
     %% copied to the child and not through the supervisor as well.
     {ok, Pid} = supervisor:start_child(wasm_jit_sup, []),

--- a/test/wasm_jit_lifetime_SUITE.erl
+++ b/test/wasm_jit_lifetime_SUITE.erl
@@ -40,7 +40,8 @@ all() ->
      a_caller_that_never_destroys_keeps_a_bounded_entry_cache,
      a_module_split_across_shards_answers_the_same,
      a_profile_sets_what_you_did_not,
-     an_unknown_profile_is_a_value_not_a_crash].
+     an_unknown_profile_is_a_value_not_a_crash,
+     both_engines_answer_the_same_bad_arguments].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(wasm),
@@ -617,6 +618,53 @@ serve() ->
     end.
 
 %%% -------------------------------------------------------------- helpers ---
+
+%% The two engines answer a bad argument the same way.
+%%
+%% `wasm_exec:check_arity/2` guards the interpreter and the compiled tier never
+%% reaches it, so the same mistake used to answer `{link, argument_arity}`
+%% interpreted and `{malformed, internal}` compiled, and which one an embedder
+%% saw depended on whether the function was hot yet. Types were checked on
+%% neither: a float where an i32 belonged crashed the interpreter into a
+%% captured error, and the tier ran `i32.add` on it and answered `{ok, [-2.5]}`.
+%%
+%% Both arms call with a valid argument first, which is what makes the second
+%% arm compiled at all. The counter assertion is the non-vacuity half: without
+%% it this passes just as well with the tier switched off, comparing the
+%% interpreter against itself.
+both_engines_answer_the_same_bad_arguments(_Config) ->
+    %% Straight-line, not `loop_wat/0`. Before the check existed the tier ran
+    %% `i32.eqz` against a float, never matched, and spun for ever: the first
+    %% version of this case did not fail against the parent commit, it hung.
+    M = build(~"(module (func (export \"f\") (param i32) (result i32)
+                  local.get 0 i32.const 1 i32.add))"),
+    Bad = [[], [1, 2], [1.5], [-3.5], [<<"x">>], [null]],
+    Interp = answers(M, #{}, Bad),
+    wasm_jit:reset_counts(),
+    Jit = answers(M, sync_opts(), Bad),
+    #{entered := Entered} = wasm_jit:counts(),
+    ?assert(Entered > 0, "the compiled tier was never entered, so this case "
+                         "compared the interpreter with itself"),
+    ?assertEqual(Interp, Jit),
+    %% And every one of them is a link error naming the problem, rather than an
+    %% internal one or, worse, an answer.
+    [?assertMatch({link, K} when K =:= argument_arity orelse
+                                 K =:= argument_type, A)
+     || A <- Interp].
+
+%% One instance, a valid call to make it hot, then each bad argument list.
+answers(M, Opts, Argss) ->
+    {ok, I} = wasm:instantiate(M, #{}, Opts),
+    try
+        {ok, [11]} = wasm:call(I, ~"f", [10]),
+        {ok, [11]} = wasm:call(I, ~"f", [10]),
+        [case wasm:call(I, ~"f", A) of
+             {ok, V} -> {ok, V};
+             {error, #{class := C, kind := K}} -> {C, K}
+         end || A <- Argss]
+    after
+        wasm:destroy(I)
+    end.
 
 opts() -> #{compile => true, compile_after => 1}.
 

--- a/test/wasm_resource_SUITE.erl
+++ b/test/wasm_resource_SUITE.erl
@@ -36,6 +36,8 @@ the node's life.
          a_keeper_restart_keeps_the_ceiling_it_promised/1,
          an_aborted_growth_does_not_block_the_next_one/1,
          an_engine_restart_keeps_the_store_and_the_waiters/1,
+         each_subsystem_has_its_own_restart_budget/1,
+         a_table_owner_crash_does_not_lose_the_tables/1,
          restarts_under_traffic_leave_nothing_behind/1]).
 
 all() ->
@@ -61,6 +63,8 @@ all() ->
      a_keeper_restart_keeps_the_ceiling_it_promised,
      an_aborted_growth_does_not_block_the_next_one,
      an_engine_restart_keeps_the_store_and_the_waiters,
+     each_subsystem_has_its_own_restart_budget,
+     a_table_owner_crash_does_not_lose_the_tables,
      restarts_under_traffic_leave_nothing_behind].
 
 init_per_suite(Config) ->
@@ -607,6 +611,56 @@ an_engine_restart_keeps_the_store_and_the_waiters(_Config) ->
     receive {woke, 0} -> ok after 5000 -> ct:fail({stranded, Waiter}) end,
     ok = wasm_table:release(Table, {process, self()}).
 
+%% A subsystem's restart budget is its own.
+%%
+%% Flat under one supervisor these five shared `intensity => 5, period => 10',
+%% so a workload that only ever lost its module cache could take the engine, the
+%% keeper and the code slots down with it, and did: a stress run killed six
+%% children in half a second and the application went with them. Eight cache
+%% deaths inside the old window is the shape that used to be fatal.
+%%
+%% The assertion is on the *other* subsystems. That the cache comes back says
+%% only that a supervisor restarts children; that the engine, keeper and slot
+%% manager are the same processes they were is what says the budget is no longer
+%% shared.
+each_subsystem_has_its_own_restart_budget(_Config) ->
+    ok = application:stop(wasm),
+    {ok, _} = application:ensure_all_started(wasm),
+    Engine = whereis(wasm_engine),
+    Keeper = whereis(wasm_keeper),
+    Slots = whereis(wasm_code_slots),
+    _ = [begin kill(wasm_module_cache), timer:sleep(80) end
+         || _ <- lists:seq(1, 8)],
+    wait_until(fun() -> is_pid(whereis(wasm_module_cache)) end, 5000),
+    ?assert(lists:keymember(wasm, 1, application:which_applications())),
+    ?assertEqual(Engine, whereis(wasm_engine)),
+    ?assertEqual(Keeper, whereis(wasm_keeper)),
+    ?assertEqual(Slots, whereis(wasm_code_slots)).
+
+%% The tables outlive the process that owns them.
+%%
+%% `wasm_store' holds them and names `wasm_store_sup' as their heir, so killing
+%% the owner transfers them rather than destroying them, and the replacement
+%% finds them already there and leaves them alone. Killing twice is the half
+%% that matters: the first crash moves ownership to the supervisor, and a
+%% version that tried to take the tables back would fail on the second.
+a_table_owner_crash_does_not_lose_the_tables(_Config) ->
+    Row = {{marker, make_ref()}, keep, 7, #{}},
+    true = ets:insert(wasm_holders, Row),
+    Sup = whereis(wasm_store_sup),
+    _ = [begin
+             Pid = whereis(wasm_store),
+             kill(wasm_store),
+             wait_until(fun() -> is_pid(whereis(wasm_store)) andalso
+                                     whereis(wasm_store) =/= Pid end, 5000)
+         end || _ <- lists:seq(1, 2)],
+    %% Every table still there, and holding what it held.
+    [?assertNotEqual(undefined, ets:info(T, name)) || T <- wasm_store:tables()],
+    ?assertEqual([Row], ets:lookup(wasm_holders, element(1, Row))),
+    ?assertEqual(Sup, ets:info(wasm_holders, owner)),
+    true = ets:delete(wasm_holders, element(1, Row)),
+    ok.
+
 %% The restart cases above each stop the world first. This one does not: it
 %% kills the keeper, the engine and the module cache repeatedly while
 %% instances are being made, called and destroyed, which is the shape a
@@ -615,11 +669,12 @@ an_engine_restart_keeps_the_store_and_the_waiters(_Config) ->
 %% What it asserts is the invariant the whole resource model rests on: when the
 %% traffic stops, nothing is left charged and nothing is left in the store.
 %%
-%% Within what the tree promises, which is `intensity => 5, period => 10'.
-%% Killing harder than that is not a stronger test, it is a different one: the
-%% first version killed three children six times in a quarter of a second, the
-%% supervisor gave up as it is designed to, and the application went down
-%% taking the tables with it. That is the tree working.
+%% Within what the tree promises, which is now `intensity => 10, period => 60'
+%% per subsystem rather than five in ten across all of them. Killing harder than
+%% that is not a stronger test, it is a different one: the first version killed
+%% three children six times in a quarter of a second, the supervisor gave up as
+%% it is designed to, and the application went down taking the tables with it.
+%% That is still the tree working; there is simply more room before it.
 restarts_under_traffic_leave_nothing_behind(Config) ->
     %% On a fresh tree, because a supervisor's restart budget is shared with
     %% every other case that kills something and this one spends four of it.

--- a/test/wasm_resource_SUITE.erl
+++ b/test/wasm_resource_SUITE.erl
@@ -36,6 +36,7 @@ the node's life.
          a_keeper_restart_keeps_the_ceiling_it_promised/1,
          an_aborted_growth_does_not_block_the_next_one/1,
          an_engine_restart_keeps_the_store_and_the_waiters/1,
+         a_tree_death_does_not_leak_the_page_budget/1,
          each_subsystem_has_its_own_restart_budget/1,
          a_table_owner_crash_does_not_lose_the_tables/1,
          restarts_under_traffic_leave_nothing_behind/1]).
@@ -63,6 +64,7 @@ all() ->
      a_keeper_restart_keeps_the_ceiling_it_promised,
      an_aborted_growth_does_not_block_the_next_one,
      an_engine_restart_keeps_the_store_and_the_waiters,
+     a_tree_death_does_not_leak_the_page_budget,
      each_subsystem_has_its_own_restart_budget,
      a_table_owner_crash_does_not_lose_the_tables,
      restarts_under_traffic_leave_nothing_behind].
@@ -636,6 +638,60 @@ each_subsystem_has_its_own_restart_budget(_Config) ->
     ?assertEqual(Engine, whereis(wasm_engine)),
     ?assertEqual(Keeper, whereis(wasm_keeper)),
     ?assertEqual(Slots, whereis(wasm_code_slots)).
+
+%% Losing the tree costs the node its page budget, permanently, unless the
+%% counter is put back in step with the registry.
+%%
+%% The counter is an `atomics' array in `persistent_term' and outlives
+%% everything; the registry is a table and does not. Before this, killing the
+%% tree with four 8-page instances alive left 32 pages charged to memories whose
+%% monitors were gone: destroying every instance released nothing, restarting
+%% the application released nothing, and the budget stayed spent for the life of
+%% the node. It accumulated, one tree death at a time.
+%%
+%% The registry is the truth here, because it is the only thing that can give a
+%% page back. A registry that came back empty means nothing is releasable, so
+%% zero is the honest count.
+a_tree_death_does_not_leak_the_page_budget(_Config) ->
+    ok = application:stop(wasm),
+    {ok, _} = application:ensure_all_started(wasm),
+    Mod = compile(~"(module (memory (export \"m\") 8))"),
+    Insts = [begin {ok, I} = wasm:instantiate(Mod, #{}), I end
+             || _ <- lists:seq(1, 4)],
+    ?assert(wasm_engine:pages_in_use() >= 32),
+
+    Sup = whereis(wasm_sup),
+    Ref = monitor(process, Sup),
+    exit(Sup, kill),
+    receive {'DOWN', Ref, _, _, _} -> ok after 5000 -> ct:fail(alive) end,
+    wait_until(fun() -> not lists:keymember(wasm, 1,
+                                            application:which_applications())
+               end, 5000),
+    {ok, _} = application:ensure_all_started(wasm),
+
+    %% The registry came back empty, so the counter has to say so too. Asserting
+    %% against the registry rather than against zero is the point: what must
+    %% hold is that the two agree, and zero is only what that happens to be
+    %% after a total loss.
+    ?assertEqual(registry_pages(), wasm_engine:pages_in_use()),
+    ?assertEqual(0, registry_pages()),
+
+    %% And the node still allocates the full budget afterwards, which is the
+    %% thing the leak took away.
+    {ok, Fresh} = wasm:instantiate(Mod, #{}),
+    ?assertEqual(8, wasm_engine:pages_in_use()),
+    ok = wasm:destroy(Fresh),
+    ?assertEqual(0, wasm_engine:pages_in_use()),
+    _ = Insts,
+    ok.
+
+%% What the registry says is charged, summed per resource row. Not per holder:
+%% a memory two instances share is one charge, and `wasm_keeper:adopt_totals/0`
+%% counts it twice on purpose because it is building per-token totals.
+registry_pages() ->
+    ets:foldl(fun({_Res, _Meta, Pages, H}, Acc) when is_map(H) -> Acc + Pages;
+                 (_Other, Acc) -> Acc
+              end, 0, wasm_holders).
 
 %% The tables outlive the process that owns them.
 %%

--- a/test/wasm_threads_SUITE.erl
+++ b/test/wasm_threads_SUITE.erl
@@ -369,12 +369,17 @@ a_notifier_that_dies_holding_a_wakeup_does_not_fake_one(_Config) ->
 %% a fallback that created it in whichever agent got there first, taken when
 %% the application was not running; it is gone, and an unsupervised engine is
 %% started on demand instead.
+%%
+%% `wasm_store` owns it now, with `wasm_store_sup` as its heir, so the list of
+%% acceptable owners is those two plus the engine that creates it when there is
+%% no application at all. What the case is really about is the last line.
 the_waiter_table_never_belongs_to_a_waiter(_Config) ->
     MemId = make_ref(),
     %% Force the table into existence through the ordinary path.
     0 = wasm_wait:notify(MemId, 0, 1),
     Owner = ets:info(wasm_waiters, owner),
-    ?assert(Owner =:= whereis(wasm_sup) orelse Owner =:= whereis(wasm_engine)),
+    ?assert(lists:member(Owner, [whereis(wasm_store), whereis(wasm_store_sup),
+                                 whereis(wasm_engine)])),
     ?assertNotEqual(self(), Owner).
 
 %%% ---------------------------------------------------------------- setup ---

--- a/test/wasm_threads_SUITE.erl
+++ b/test/wasm_threads_SUITE.erl
@@ -40,7 +40,8 @@ all() ->
      a_notifier_that_dies_holding_a_wakeup_does_not_fake_one,
      the_waiter_table_never_belongs_to_a_waiter,
      wait_on_an_unshared_memory_traps,
-     a_shared_memory_outlives_the_process_that_made_it].
+     a_shared_memory_outlives_the_process_that_made_it,
+     a_fence_validates_and_runs].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(wasm),
@@ -381,6 +382,34 @@ the_waiter_table_never_belongs_to_a_waiter(_Config) ->
     ?assert(lists:member(Owner, [whereis(wasm_store), whereis(wasm_store_sup),
                                  whereis(wasm_engine)])),
     ?assertNotEqual(self(), Owner).
+
+%% `atomic.fence` is the one instruction in the `0xFE` space that is a bare
+%% atom rather than a memory access, so it reached neither the atomic table nor
+%% anything else, and every module carrying one was rejected as invalid. The
+%% decoder and the interpreter both knew it; only the validator did not.
+%%
+%% Nothing upstream covers it: `proposals/threads/atomic.wast` contains no
+%% `atomic.fence`, which is why a baseline keyed to the specification suite ran
+%% green over this for as long as it did. Both shapes are here because a fence
+%% needs no memory to be valid, and requiring one would be the obvious wrong
+%% fix.
+a_fence_validates_and_runs(_Config) ->
+    WithMemory = ~"""
+    (module (memory 1 1 shared)
+      (func (export "f") (result i32)
+        atomic.fence
+        (i32.atomic.store (i32.const 0) (i32.const 7))
+        atomic.fence
+        (i32.atomic.load (i32.const 0))))
+    """,
+    WithoutMemory = ~"(module (func (export \"f\") (result i32) atomic.fence i32.const 42))",
+    ?assertEqual({ok, [7]}, run(WithMemory)),
+    ?assertEqual({ok, [42]}, run(WithoutMemory)).
+
+run(Wat) ->
+    {ok, Mod} = wasm:compile({wat, Wat}),
+    {ok, Inst} = wasm:instantiate(Mod, #{}),
+    try wasm:call(Inst, ~"f", []) after wasm:destroy(Inst) end.
 
 %%% ---------------------------------------------------------------- setup ---
 


### PR DESCRIPTION
A read-only stress run against 0.1.1 found four things the project's own gates
structurally could not see. This fixes all four, one commit each.

## The supervision half

`wasm_sup` was `one_for_one, intensity 5, period 10` over five servers, so the
budget was shared: losing the module cache repeatedly could take the engine, the
keeper and the code slots with it. Each subsystem now has its own supervisor and
its own `10 in 60`, and `wasm_store` owns the long-lived tables with its
supervisor as heir.

The split alone would not have been enough, because the sharper problem was
underneath it. The page counter is an `atomics` array in `persistent_term` and
outlives everything; the registry that says who holds those pages is a table
that does not. A tree death left pages charged to memories whose monitors were
gone:

```
4 instances x 32 pages          pages_in_use = 128   registry rows = 8
kill the tree                   pages_in_use = 128   registry rows = 0
destroy all 4 instances         pages_in_use = 128   registry rows = 0
application:ensure_all_started  pages_in_use = 128   registry rows = 0
```

It accumulated, one tree death at a time, until a node restart. `wasm_keeper`
now reconciles the counter against the registry when it starts, which needs no
locking because every `reserve_pages/1` and `release_pages/1` call in the
runtime is made from that process. Losing the tables became a clean reset
instead of a leak.

Two things worth stating rather than discovering later:

- Nothing inside a supervision tree survives the root of that tree dying, heir
  included. The split makes root death rare; the reconciliation makes it
  harmless.
- An OTP supervisor has no `handle_info` for `ETS-TRANSFER`, so naming one as
  heir costs a `"Supervisor received unexpected message"` report per transfer.
  `wasm_store` holds tables and runs no logic, so that should be approximately
  never.

## The three defects

- **`atomic.fence` was rejected as invalid.** `wasm_decode_atomic` decodes it and
  `wasm_exec` runs it; the validator had no clause. The specification suite
  cannot catch this: `proposals/threads/atomic.wast` contains no `atomic.fence`,
  so the baseline had nothing to fail on. It was the only rejection of an
  externally valid module across 620 generated ones, and accounted for all 24.
- **An invalid limits map failed open.** `#{max_depth => lots}` let a guest
  recurse a million frames, because every integer sorts before every atom so
  `Depth >= MaxDepth` was never true. `wasm_limits:validate/1` already answered
  correctly and nothing called it.
- **Argument checks existed on one engine only.** `wasm_exec:check_arity/2`
  guards the interpreter and the compiled tier enters generated code directly,
  so a wrong arity answered `{link, argument_arity}` interpreted and
  `{malformed, internal}` compiled, and which one you got depended on whether the
  function was hot yet. Types were checked on neither: a float passed for an
  `i32` was rejected by the interpreter and had `i32.add` run on it by the tier,
  answering `{ok, [-2.5]}`. Both are checked once now, before either engine is
  chosen.

## Behaviour change

A wrong-typed call argument answers `{link, argument_type}` where it used to
answer `{malformed, internal}`. `malformed` is the decode class and an argument
is not a decode concern, but the class has changed and the kind is new.

## Numbers

410 to 416 cases, a case per defect, each run against its parent commit and seen
to fail first. Unchanged: 65,481 specification assertions in both engines with 0
fail and 0 skip, the tier still `compiled=4894, entered=49828`, WASI 72/72
native and 68/72 fallback, 301/301 agreement with wasmtime, zero raises across
2,033 malformed inputs, zero interpreter/tier mismatches.

The ten concurrency suites run together at 1, 14 and 28 schedulers: 148/148,
where before they failed five cases at every count.

QuickJS held flat, recorded in `test/audit/PERF.md`: base 1653.8 ms against
1659.8 ms over five interleaved pairs. That establishes no large regression
rather than no regression, since the base arm's own spread was 1653.8 to
2760.5 ms on the same box.