### PR TITLE
Take the allocation out of the GC bulk array path

### DIFF
--- a/bench/paths/perinstr.erl
+++ b/bench/paths/perinstr.erl
@@ -1,6 +1,26 @@
 -module(perinstr).
 -export([main/1]).
 
+%% Two things have to be true of a snippet repeated K times before it measures
+%% anything, and this file has now got each of them wrong once:
+%%
+%%   - the result must be used, or it is dead code and the SSA pass drops it;
+%%   - each copy must depend on the copy before it. Forty `local.set $t' from
+%%     independent expressions are thirty-nine dead stores, and one operand
+%%     that does not change across iterations is hoisted out of the loop.
+%%
+%% So the result accumulates into the local it reads, and one operand is xored
+%% with the loop counter. That is what `i32.add' has always done, which is why
+%% it was the row that reported a number while `i32.shl' reported zero.
+-define(VARY(Op, Operand),
+        "(local.set $t (i32.add (local.get $t) (" Op
+        " (i64.xor (local.get " Operand
+        ") (i64.extend_i32_u (local.get $i))) (i64.const 5))))").
+-define(VARYSH(Op, Operand),
+        "(local.set $u (i64.add (local.get $u) (" Op
+        " (i64.xor (local.get " Operand
+        ") (i64.extend_i32_u (local.get $i))) (i64.const 1))))").
+
 %% The marginal cost of one instruction: build the same loop with K copies of a
 %% snippet and with 2K, and take the difference. Everything the two runs share,
 %% loop overhead included, cancels.
@@ -12,7 +32,10 @@
 %% The tier arm is the one that matters now. A warm QuickJS run makes *zero*
 %% `wasm_exec:run/3` calls (`bench/paths/tiered.erl`), so nothing it does is
 %% interpreted and only these prices explain where its time goes.
-main([Tier]) ->
+%% An optional second argument runs only the cases whose name contains it, so
+%% a probe into one instruction does not pay for `memory.copy 1024B' twice.
+main([Tier]) -> main([Tier, ""]);
+main([Tier, Only]) ->
     {ok, _} = application:ensure_all_started(wasm),
     Opts = case Tier of
                "off" -> #{};
@@ -65,11 +88,47 @@ main([Tier]) ->
          %% deep nest of them, and every dispatch re-enters the whole nest.
          {"block, empty           ", "(block (nop))", 1},
          {"block x8 nested        ", "(block (block (block (block (block (block (block (block (nop)))))))))", 8},
+         %% What `wasm_core:uns(64, _)' costs. It is `band 16#FFFFFFFFFFFFFFFF',
+         %% a literal past the 60-bit immediate range, on values already held
+         %% in [-2^63, 2^63), and it is reached by `i64.shr_u' and by every
+         %% unsigned 64-bit comparison. Not by `i64.div_u' or `i64.rem_u':
+         %% neither has an `inline/1' clause, so both call `wasm_exec:op2/3'.
+         %%
+         %% Each unsigned form sits next to its signed twin, which does no
+         %% masking at all, and each pair runs twice: on a value that is small
+         %% and non-negative, and on one with the top bit set, because a range
+         %% test would treat those two differently and a mask does not.
+         %% `$h' comes from the loop bound so it cannot be folded away.
+         %% `local.set' and not `drop': every one of these measured 0.00 in the
+         %% `drop' form, because a computation whose result is dropped is dead
+         %% and the SSA pass removes it. `$t' and `$u' are locals, and a
+         %% `local.set' to a local nothing reads survives, which is why the
+         %% rows above are written that way too.
+         %% Read these as *pairs*: each unsigned form sits next to its signed
+         %% twin, which is the same instruction without the mask, and the
+         %% difference between the two is what `uns/2' costs. Neither absolute
+         %% number means much, because both carry the `xor' and the extend.
+         %%
+         %% Those two are what make the operand vary. Written against a
+         %% loop-invariant local the whole expression is hoisted out of the
+         %% loop and every row reads 0.00, which is how the first version of
+         %% these rows reported that unsigned comparison is free.
+         {"i64.lt_s, small       ", ?VARY("i64.lt_s", "$sm"), 9},
+         {"i64.lt_u, small       ", ?VARY("i64.lt_u", "$sm"), 9},
+         {"i64.lt_s, high bit    ", ?VARY("i64.lt_s", "$h"), 9},
+         {"i64.lt_u, high bit    ", ?VARY("i64.lt_u", "$h"), 9},
+         {"i64.ge_s, high bit    ", ?VARY("i64.ge_s", "$h"), 9},
+         {"i64.ge_u, high bit    ", ?VARY("i64.ge_u", "$h"), 9},
+         {"i64.shr_s, small      ", ?VARYSH("i64.shr_s", "$sm"), 9},
+         {"i64.shr_u, small      ", ?VARYSH("i64.shr_u", "$sm"), 9},
+         {"i64.shr_s, high bit   ", ?VARYSH("i64.shr_s", "$h"), 9},
+         {"i64.shr_u, high bit   ", ?VARYSH("i64.shr_u", "$h"), 9},
          {"br_table 4 of 8 nested ",
           "(block $a (block $b (block $c (block $d (block $e (block $f (block $g (block $h (br_table $a $b $c $d $e $f $g $h (local.get $i))))))))))",
           9}],
     io:format("~-24s ~10s ~10s~n", ["snippet", "ns/snip", "ns/instr"]),
-    [run_case(Name, Snip, Instrs) || {Name, Snip, Instrs} <- Cases],
+    [run_case(Name, Snip, Instrs) || {Name, Snip, Instrs} <- Cases,
+                                     string:find(Name, Only) =/= nomatch],
     init:stop().
 
 run_case(Name, Snippet, Instrs) ->
@@ -77,7 +136,14 @@ run_case(Name, Snippet, Instrs) ->
     T1 = time_for(Snippet, K),
     T2 = time_for(Snippet, 2 * K),
     Per = (T2 - T1) / K,
-    io:format("~-24s ~10.2f ~10.2f~n", [Name, Per, Per / Instrs]).
+    io:format("~-24s ~10.2f ~10.2f~s~n", [Name, Per, Per / Instrs, note(Per)]).
+
+%% A snippet that costs nothing usually was not run. Ten of them were added to
+%% this file in the `(drop ...)' form, which is dead code the SSA pass removes,
+%% and every one reported 0.00 as though the instruction were free. Say so in
+%% the row rather than leaving a reader to notice the zero.
+note(Per) when Per < 0.05 -> "   <- eliminated, or below the noise floor";
+note(_Per) -> "".
 
 %% ns per iteration for a loop whose body holds `K' copies of the snippet
 time_for(Snippet, K) ->
@@ -105,6 +171,12 @@ source(Snippet, K) ->
        " (global $g (mut i32) (i32.const 0))\n",
        " (func (export \"bench\") (param $n i32) (result i32)\n",
        "  (local $i i32) (local $t i32) (local $u i64) (local $f f64)\n",
+       "  (local $h i64) (local $sm i64)\n",
+       %% Every bit set above the loop bound, so `$h' is high-bit unsigned and
+       %% comes from a parameter: a constant would be propagated into the loop
+       %% and the masks folded away with it.
+       "  (local.set $h (i64.sub (i64.const 0) (i64.extend_i32_u (local.get $n))))\n",
+       "  (local.set $sm (i64.extend_i32_u (local.get $n)))\n",
        "  (block $done (loop $l\n",
        "    (br_if $done (i32.ge_u (local.get $i) (local.get $n)))\n        ",
        Body,

--- a/bench/paths/perinstr.erl
+++ b/bench/paths/perinstr.erl
@@ -16,10 +16,16 @@
         "(local.set $t (i32.add (local.get $t) (" Op
         " (i64.xor (local.get " Operand
         ") (i64.extend_i32_u (local.get $i))) (i64.const 5))))").
--define(VARYSH(Op, Operand),
+%% The counter is shifted up 40 before it is xored in. Xored in at the bottom
+%% it varies bits 0 to 17 only, which a shift of 47 discards, and the whole
+%% expression goes back to being loop-invariant: the `>> 47' rows read 0.79 ns
+%% on both sides of a change to exactly that code before this was noticed.
+-define(VARYSH(Op, Operand), ?VARYSH(Op, Operand, "1")).
+-define(VARYSH(Op, Operand, By),
         "(local.set $u (i64.add (local.get $u) (" Op
         " (i64.xor (local.get " Operand
-        ") (i64.extend_i32_u (local.get $i))) (i64.const 1))))").
+        ") (i64.shl (i64.extend_i32_u (local.get $i)) (i64.const 40)))"
+        " (i64.const " By "))))").
 
 %% The marginal cost of one instruction: build the same loop with K copies of a
 %% snippet and with 2K, and take the difference. Everything the two runs share,
@@ -119,10 +125,18 @@ main([Tier, Only]) ->
          {"i64.lt_u, high bit    ", ?VARY("i64.lt_u", "$h"), 9},
          {"i64.ge_s, high bit    ", ?VARY("i64.ge_s", "$h"), 9},
          {"i64.ge_u, high bit    ", ?VARY("i64.ge_u", "$h"), 9},
-         {"i64.shr_s, small      ", ?VARYSH("i64.shr_s", "$sm"), 9},
-         {"i64.shr_u, small      ", ?VARYSH("i64.shr_u", "$sm"), 9},
-         {"i64.shr_s, high bit   ", ?VARYSH("i64.shr_s", "$h"), 9},
-         {"i64.shr_u, high bit   ", ?VARYSH("i64.shr_u", "$h"), 9},
+         {"i64.shr_s, small      ", ?VARYSH("i64.shr_s", "$sm"), 11},
+         {"i64.shr_u, small      ", ?VARYSH("i64.shr_u", "$sm"), 11},
+         {"i64.shr_s, high bit   ", ?VARYSH("i64.shr_s", "$h"), 11},
+         {"i64.shr_u, high bit   ", ?VARYSH("i64.shr_u", "$h"), 11},
+         %% By 47 as well as by 1, because they are different code. A logical
+         %% shift of a high-bit value by less than six leaves an answer of at
+         %% least 2^58, which is past the immediate range whatever the
+         %% generator does; by six or more the answer fits, and a toolchain
+         %% pulling a tag out of a NaN-boxed word shifts by far more than six.
+         {"i64.shr_s, high >> 47 ", ?VARYSH("i64.shr_s", "$h", "47"), 11},
+         {"i64.shr_u, high >> 47 ", ?VARYSH("i64.shr_u", "$h", "47"), 11},
+         {"i64.shr_u, small >> 47", ?VARYSH("i64.shr_u", "$sm", "47"), 11},
          {"br_table 4 of 8 nested ",
           "(block $a (block $b (block $c (block $d (block $e (block $f (block $g (block $h (br_table $a $b $c $d $e $f $g $h (local.get $i))))))))))",
           9}],

--- a/bench/paths/perinstr.erl
+++ b/bench/paths/perinstr.erl
@@ -66,6 +66,16 @@ main([Tier, Only]) ->
          {"f64.add                ", "(local.set $f (f64.add (local.get $f) (f64.const 1)))", 3},
          {"i32.load               ", "(local.set $t (i32.load (i32.const 0)))", 3},
          {"call (empty func)      ", "(call $empty)", 1},
+         %% Four of the rows around here used to read 1.95 to 4.73 ns and now
+         %% read 0.00, and the snippets have not changed: the compile quality
+         %% default has moved between `baseline' and `full' since they were
+         %% written, and at `full' the SSA pass collapses forty shifts of one
+         %% local into one shift, and drops thirty-nine stores to a local
+         %% nothing reads. Each now xors the loop counter into the operand, or
+         %% accumulates, so no copy is the same computation as the one before
+         %% it. The numbers in `PERF.md''s price table predate this and were
+         %% taken at the other quality.
+         %%
          %% Everything below is here because QuickJS pays for it and the
          %% original set did not cover it.
          {"i32.store              ", "(i32.store (i32.const 0) (local.get $i))", 3},
@@ -75,13 +85,17 @@ main([Tier, Only]) ->
          {"i64.store              ", "(i64.store (i32.const 0) (local.get $u))", 3},
          {"f64.load               ", "(local.set $f (f64.load (i32.const 0)))", 3},
          {"f64.store              ", "(f64.store (i32.const 0) (local.get $f))", 3},
-         {"f64.convert_i32_u      ", "(local.set $f (f64.convert_i32_u (local.get $i)))", 3},
+         {"f64.convert_i32_u      ", "(local.set $f (f64.add (local.get $f) (f64.convert_i32_u (local.get $i))))", 5},
          {"i32.trunc_f64_u        ", "(local.set $t (i32.trunc_f64_u (local.get $f)))", 3},
          {"f64.mul                ", "(local.set $f (f64.mul (local.get $f) (local.get $f)))", 3},
-         {"i32.mul                ", "(local.set $t (i32.mul (local.get $t) (local.get $i)))", 4},
+         %% The null arm for the four rows that had to be repaired: they price
+         %% their instruction *and* the xor that keeps each copy dependent on
+         %% the one before it, so subtract this to read them.
+         {"i32.xor, the null arm ", "(local.set $t (i32.xor (local.get $t) (local.get $i)))", 4},
+         {"i32.mul                ", "(local.set $t (i32.mul (i32.xor (local.get $t) (local.get $i)) (local.get $i)))", 6},
          {"i32.div_u              ", "(local.set $t (i32.div_u (local.get $i) (i32.const 3)))", 4},
-         {"i32.shl                ", "(local.set $t (i32.shl (local.get $t) (i32.const 1)))", 4},
-         {"i64.shl                ", "(local.set $u (i64.shl (local.get $u) (i64.const 1)))", 4},
+         {"i32.shl                ", "(local.set $t (i32.shl (i32.xor (local.get $t) (local.get $i)) (i32.const 1)))", 6},
+         {"i64.shl                ", "(local.set $u (i64.shl (i64.xor (local.get $u) (i64.extend_i32_u (local.get $i))) (i64.const 1)))", 7},
          {"call_indirect          ", "(call_indirect (type $void) (i32.const 0))", 2},
          {"global.get + drop      ", "(drop (global.get $g))", 2},
          {"global.set             ", "(global.set $g (local.get $i))", 2},

--- a/src/wasm_exec.erl
+++ b/src/wasm_exec.erl
@@ -716,13 +716,10 @@ run([{array_copy, D, _Src} | Rest], Ctrl,
     check_array_range(H, SrcR, SrcStart, Len),
     check_array_range(H, DstR, DstStart, Len),
     _ = D,
-    %% Read every source element before writing any of them, so an overlapping
-    %% copy behaves. The list is then consumed in order rather than indexed with
-    %% `lists:nth/2', which made this quadratic: 127, then 416, then 4604 ns per
-    %% element as the length went 100, 1000, 10000.
-    Vals = [wasm_heap:array_get(H, SrcR, SrcStart + I)
-            || I <- lists:seq(0, Len - 1)],
-    ok = write_elements(H, DstR, DstStart, Vals),
+    %% The loop lives in `wasm_heap' beside the accounting it has to go
+    %% through. Reading every source element before writing any of them, so an
+    %% overlapping copy behaves, is its job now and not this clause's.
+    ok = wasm_heap:array_copy(H, DstR, DstStart, SrcR, SrcStart, Len),
     run(Rest, Ctrl, St#st{stack = S});
 
 %% An array built from a data or element segment. The segment is read as the

--- a/src/wasm_heap.erl
+++ b/src/wasm_heap.erl
@@ -496,9 +496,13 @@ array_fill({wasm_heap, Objs, Elems, Ctr} = H, {objref, Id} = Ref, 0, Len, Value)
 array_fill(H, Ref, Start, Len, Value) ->
     fill_each(H, Ref, Start, Len, Value).
 
-fill_each(H, Ref, Start, Len, Value) ->
-    lists:foreach(fun(I) -> array_set_unchecked(H, Ref, Start + I, Value) end,
-                  lists:seq(0, Len - 1)).
+%% Counting down rather than over `lists:seq(0, Len - 1)': the sequence was one
+%% cons cell per element of an array the caller never sees, and the fun one
+%% call on top of the write.
+fill_each(_H, _Ref, _Idx, 0, _Value) -> ok;
+fill_each(H, Ref, Idx, N, Value) ->
+    ok = array_set_unchecked(H, Ref, Idx, Value),
+    fill_each(H, Ref, Idx + 1, N - 1, Value).
 
 -doc """
 Copy a range of elements from one array to another.

--- a/src/wasm_heap.erl
+++ b/src/wasm_heap.erl
@@ -62,7 +62,7 @@ silently name a different live object instead.
 -export([new_struct/3, new_array/5]).
 -export([get_field/3, set_field/4]).
 -export([array_len/2, array_get/3, array_set/4, array_set_unchecked/4]).
--export([array_default/2, array_fill/5]).
+-export([array_default/2, array_fill/5, array_copy/6]).
 -export([type_of/2]).
 -export([size/1, allocs/1, should_collect/1, collect/2, major_due/1]).
 -export([new/2, acquire/3, charge/1]).
@@ -499,6 +499,49 @@ array_fill(H, Ref, Start, Len, Value) ->
 fill_each(H, Ref, Start, Len, Value) ->
     lists:foreach(fun(I) -> array_set_unchecked(H, Ref, Start + I, Value) end,
                   lists:seq(0, Len - 1)).
+
+-doc """
+Copy a range of elements from one array to another.
+
+Both ranges are already checked, as they are for `array_fill/5`, so this does
+not ask again. `wasm_exec` used to hold the loop, and it read each element
+through `array_get/3`, which calls `array_len/2`, which is a table lookup per
+element re-answering the question the range check had just answered.
+
+The source's default is read once rather than per element. Most elements of an
+array have no row of their own, so `array_get/3` reaches the object table for
+every one of them, and a copy out of a defaulted array is that lookup and
+nothing else. The cost is that a whole-array fill of the source running
+concurrently, the only thing that changes a default, is not observed part way
+through a copy. Two processes writing one array while a third copies it is
+already unordered, and the snapshot below has the same property.
+
+The source is read into a list before anything is written, so an overlapping
+copy behaves as though an intermediate copy were taken, which is what the
+specification asks for.
+""".
+-spec array_copy(heap(), term(), non_neg_integer(), term(),
+                 non_neg_integer(), non_neg_integer()) -> ok.
+array_copy({wasm_heap, Objs, Elems, _} = H, DstRef, DstStart,
+           {objref, SrcId}, SrcStart, Len) ->
+    Default = ets:lookup_element(Objs, SrcId, 5),
+    write_each(H, DstRef, DstStart,
+               read_each(Elems, SrcId, Default, SrcStart, Len, [])).
+
+%% Backwards, so the list comes out in index order without a reverse.
+read_each(_Elems, _Id, _Default, _Start, 0, Acc) -> Acc;
+read_each(Elems, Id, Default, Start, N, Acc) ->
+    Idx = Start + N - 1,
+    V = case ets:lookup(Elems, {Id, Idx}) of
+            [{_, Found}] -> Found;
+            [] -> Default
+        end,
+    read_each(Elems, Id, Default, Start, N - 1, [V | Acc]).
+
+write_each(_H, _Ref, _Idx, []) -> ok;
+write_each(H, Ref, Idx, [V | Rest]) ->
+    ok = array_set_unchecked(H, Ref, Idx, V),
+    write_each(H, Ref, Idx + 1, Rest).
 
 -doc """
 The kind and declared type of an object, for `ref.test` and `ref.cast`.

--- a/src/wasm_heap.erl
+++ b/src/wasm_heap.erl
@@ -516,32 +516,49 @@ concurrently, the only thing that changes a default, is not observed part way
 through a copy. Two processes writing one array while a third copies it is
 already unordered, and the snapshot below has the same property.
 
-The source is read into a list before anything is written, so an overlapping
-copy behaves as though an intermediate copy were taken, which is what the
-specification asks for.
+An overlapping copy behaves as though an intermediate copy were taken, which is
+what the specification asks for, and it does not take one: the direction
+decides it. Reading the whole source into a list first was the other way to get
+that answer, and it costs a list per copy.
 """.
 -spec array_copy(heap(), term(), non_neg_integer(), term(),
                  non_neg_integer(), non_neg_integer()) -> ok.
-array_copy({wasm_heap, Objs, Elems, _} = H, DstRef, DstStart,
+array_copy({wasm_heap, Objs, Elems, _} = H, {objref, DstId} = DstRef, DstStart,
            {objref, SrcId}, SrcStart, Len) ->
-    Default = ets:lookup_element(Objs, SrcId, 5),
-    write_each(H, DstRef, DstStart,
-               read_each(Elems, SrcId, Default, SrcStart, Len, [])).
+    Src = {Elems, SrcId, ets:lookup_element(Objs, SrcId, 5)},
+    %% Downwards when the destination starts later inside the same array, since
+    %% copying up would overwrite source elements before they are read. Every
+    %% other case, including two different arrays and ranges that do not
+    %% overlap at all, is safe upwards.
+    case DstId =:= SrcId andalso DstStart > SrcStart of
+        true -> copy_down(H, DstRef, DstStart + Len - 1, Src,
+                          SrcStart + Len - 1, Len);
+        false -> copy_up(H, DstRef, DstStart, Src, SrcStart, Len)
+    end.
 
-%% Backwards, so the list comes out in index order without a reverse.
-read_each(_Elems, _Id, _Default, _Start, 0, Acc) -> Acc;
-read_each(Elems, Id, Default, Start, N, Acc) ->
-    Idx = Start + N - 1,
-    V = case ets:lookup(Elems, {Id, Idx}) of
-            [{_, Found}] -> Found;
-            [] -> Default
-        end,
-    read_each(Elems, Id, Default, Start, N - 1, [V | Acc]).
+copy_up(_H, _Ref, _Dst, _Src, _S, 0) -> ok;
+copy_up(H, Ref, Dst, Src, S, N) ->
+    ok = array_set_unchecked(H, Ref, Dst, elem_at(Src, S)),
+    copy_up(H, Ref, Dst + 1, Src, S + 1, N - 1).
 
-write_each(_H, _Ref, _Idx, []) -> ok;
-write_each(H, Ref, Idx, [V | Rest]) ->
-    ok = array_set_unchecked(H, Ref, Idx, V),
-    write_each(H, Ref, Idx + 1, Rest).
+copy_down(_H, _Ref, _Dst, _Src, _S, 0) -> ok;
+copy_down(H, Ref, Dst, Src, S, N) ->
+    ok = array_set_unchecked(H, Ref, Dst, elem_at(Src, S)),
+    copy_down(H, Ref, Dst - 1, Src, S - 1, N - 1).
+
+%% An element with no row of its own is the array's default, which was read
+%% once by the caller and travels in `Src'.
+%%
+%% Inlined: as a call it cost 0.4 reductions on every element copied, which is
+%% more than the lookup it wraps and enough to give back what dropping the
+%% intermediate list had just bought.
+-compile({inline, [elem_at/2]}).
+
+elem_at({Elems, Id, Default}, Idx) ->
+    case ets:lookup(Elems, {Id, Idx}) of
+        [{_, V}] -> V;
+        [] -> Default
+    end.
 
 -doc """
 The kind and declared type of an object, for `ref.test` and `ref.cast`.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -402,3 +402,12 @@ element, so it waits for a reason better than that.
 
 Measure the null before designing the optimisation. Deleting the thing you
 mean to make cheaper takes one edit and bounds the whole design's value.
+
+A per-instruction snippet measures nothing unless the optimiser cannot remove
+it, and there are three separate ways it can. `perinstr` reported 0.00 for ten
+new rows twice running: once because `(drop ...)` is dead code, once because a
+loop-invariant operand is hoisted out of the loop, and once because forty
+independent `local.set $t` are thirty-nine dead stores. Accumulate into the
+local you read, and xor an operand with the loop counter. The same reading
+says four rows already in that file measure nothing, which is why `run_case/3`
+now flags anything under 0.05 ns instead of printing a bare zero.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -403,11 +403,36 @@ element, so it waits for a reason better than that.
 Measure the null before designing the optimisation. Deleting the thing you
 mean to make cheaper takes one edit and bounds the whole design's value.
 
+**Avoiding `uns(64, _)` in `i64.shr_u` with a case on the shift count.** Two of
+the three cases genuinely do not need the mask: a non-negative value shifts
+arithmetically, and a negative one shifted by six or more is
+`(A bsr Sh) + 2^(64-Sh)` exactly, with both the addend and the answer inside
+the immediate range. It is correct -- 187 pairs across every boundary agree
+with the interpreter, with generated code entered 187 times -- and it is **two
+to three times slower** than the mask it replaces: shift by 1 went 30.16 to
+63.73, shift by 47 went 0.61 to 1.15, and the signed control did not move.
+
+The three-clause case is what costs it. `wrap(64, bsr(uns(64, A), Sh))` is
+branch-free, and the SSA type pass evidently does better with it than with
+anything guarded. That is the same lesson as `wrap_sum/2` read backwards: a
+guard helps when it *tells* the compiler a range it could not infer, and hurts
+when it hides one it could.
+
+The measurement that justified trying was also wrong, which is the other half
+of this entry. See below.
+
 A per-instruction snippet measures nothing unless the optimiser cannot remove
-it, and there are three separate ways it can. `perinstr` reported 0.00 for ten
-new rows twice running: once because `(drop ...)` is dead code, once because a
-loop-invariant operand is hoisted out of the loop, and once because forty
-independent `local.set $t` are thirty-nine dead stores. Accumulate into the
-local you read, and xor an operand with the loop counter. The same reading
-says four rows already in that file measure nothing, which is why `run_case/3`
-now flags anything under 0.05 ns instead of printing a bare zero.
+it, and there are four separate ways it can. `perinstr` reported 0.00 for ten
+new rows twice running -- `(drop ...)` is dead code, a loop-invariant operand
+is hoisted out of the loop, forty independent `local.set $t` are thirty-nine
+dead stores -- and then, worse, reported a *number* for a row that was still
+loop-invariant: the counter was xored into bits 0 to 17 and the instruction
+under test shifted them away. That version read 0.74 signed against 30.71
+unsigned and the 43x was reported as a finding. The honest pair is 26.05
+against 30.16.
+
+Accumulate into the local you read, and vary a part of the operand the
+instruction keeps. `run_case/3` flags anything under 0.05 ns, which catches the
+first three failures and not the fourth; the fourth is caught only by reading
+each unsigned row against its signed twin, which is why they are laid out in
+pairs. Four rows already in that file trip the flag.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -368,3 +368,37 @@ generator. Every trap, bound and width then has one definition, and the
 conformance suite checks both paths at once.
 
 Check the load average first. This box swings between 4 and 84.
+
+## Block accounting for bulk array operations
+
+**Charging a whole chunk of a bulk operation with one `wrote/2' instead of one
+per element.** Measured before designing it, and the measurement is why it did
+not get designed. Removing the per-element charge *entirely* is worth exactly
+**1.0 reduction an element** on all three arms (`array.fill' sparse and dense
+6.0 to 5.0, `array.copy' 7.0 to 6.0) and nothing at all in reclaimed words. In
+time that is `atomics:add_get' at **4.8 ns net** against the two ETS operations
+beside it at about 36 ns each, so the counter is about 6% of an element.
+
+That 1.0 is a ceiling, not a saving: a chunk scheme still has per-chunk work.
+And the version that just calls `wrote(H, Words)' once per chunk is wrong three
+ways, none of which the interval size fixes:
+
+- **`Extra' is checked and never reserved.** `wasm_keeper:ceilings/6' says so
+  itself. Two callers can have chunks approved against the same pre-write
+  measurement and then both write them. Per-element charging bounds each
+  unreserved approval at 12 words; a chunk raises it to the chunk.
+- **A chunk overestimates a dense overwrite.** A fill over rows that already
+  exist adds little or no ETS memory, and a chunk-sized `Extra' asks the keeper
+  to refuse as though all of it were new. That is a false refusal the current
+  path does not have, and the dense arm exists to keep it visible.
+- **A chunk size does not place a reconcile.** `crossed/2' depends on the
+  counter's phase, so a chunk no larger than the interval does not guarantee a
+  crossing inside it. A block scheme has to say how it aligns to the counter,
+  not only how big it is.
+
+The only correct shape is a keeper reserve, commit and abort for prospective
+heap words, which changes the keeper's protocol. It is worth 6% of a bulk
+element, so it waits for a reason better than that.
+
+Measure the null before designing the optimisation. Deleting the thing you
+mean to make cheaper takes one edit and bounds the whole design's value.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3293,3 +3293,62 @@ to nanoseconds and an ETS BIF is the case where they come apart furthest.
 Six per cent, against a design that needs the keeper to reserve prospective
 words rather than only check them. `ATTEMPTS.md` has the three ways the cheap
 version is wrong and why the correct one waits.
+
+## What `uns(64, _)` costs: nothing on a comparison, 43x on a shift
+
+`wasm_core:uns(64, E)` is `band 16#FFFFFFFFFFFFFFFF`, a literal past the 60-bit
+immediate range, applied to values already held in `[-2^63, 2^63)`. It is
+reached by `i64.shr_u` and by every unsigned 64-bit comparison, and **not** by
+`i64.div_u` or `i64.rem_u`: neither has an `inline/1` clause, so both generate a
+call to `wasm_exec:op2/3`.
+
+Each unsigned form measured next to its signed twin, which is the same
+instruction without the mask. Generated code, load average 4, `perinstr`:
+
+| snippet | ns/snippet |
+| --- | ---: |
+| `i64.lt_s`, small | 0.99 |
+| `i64.lt_u`, small | 1.05 |
+| `i64.lt_s`, high bit | 0.98 |
+| `i64.lt_u`, high bit | 0.85 |
+| `i64.ge_s`, high bit | 1.12 |
+| `i64.ge_u`, high bit | 0.87 |
+| `i64.shr_s`, small | 0.64 |
+| `i64.shr_u`, small | 0.55 |
+| `i64.shr_s`, high bit | 0.74 |
+| **`i64.shr_u`, high bit** | **30.71** |
+
+Three runs of the last row: 30.71, 31.18, 30.81, against 0.71 to 0.74 for its
+signed twin. Everything else is a wash.
+
+**The comparisons are free and the shift is not**, and the shape says why:
+`i64.shr_u` is `wrap(64, bsr(uns(64, A), _))`, so a negative `A` becomes a
+bignum in `uns/2` and then goes through `wrap/2`'s `band`, `bxor` and `-`,
+which are three more. A comparison masks and then compares once.
+
+So the change worth making is to `i64.shr_u` and not to `uns/2` in general, and
+it is not made here. The cheap form has to case on the shift amount: the
+identity that avoids the bignum is `(A bsr S) + (1 bsl (64 - S))` for a
+negative `A`, and `1 bsl (64 - S)` is itself past the immediate range until `S`
+reaches 5. That is a real piece of code generation with a silent failure mode,
+it is not the bulk array path this branch is about, and it now has a number to
+justify it.
+
+### It took three tries to make the probe measure anything
+
+Every row read 0.00 twice before it read 30.71, and each time for a different
+reason. This is the failure ATTEMPTS.md names, met three ways in one afternoon:
+
+1. **`(drop (i64.lt_u ...))`.** A computation whose result is dropped is dead
+   and the SSA pass deletes it.
+2. **A loop-invariant operand.** `(i64.lt_u (local.get $h) (i64.const 5))` with
+   `$h` set before the loop is hoisted out of it entirely.
+3. **Repeated `local.set $t`.** Forty independent writes to one local are
+   thirty-nine dead stores; only the last survives.
+
+The fix is what `i32.add` had been doing all along, which is why it was the row
+that reported a number while `i32.shl` reported zero: accumulate into the local
+you read, and xor one operand with the loop counter. `run_case/3` now prints
+`<- eliminated, or below the noise floor` beside any row under 0.05 ns, so the
+next reader does not have to notice a zero. It fires on four rows that were
+already in the file.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3252,3 +3252,44 @@ What is left in an element is two ETS operations and one `atomics:add_get`.
 Whether the atomic is worth removing is the next measurement, not the next
 change: see the bulk plan's fourth step for why a block reservation as it
 stands would be a false refusal waiting to happen.
+
+## What the per-element charge costs, measured by deleting it
+
+The fourth step of the bulk plan was block accounting. It is a measurement
+instead, and the measurement is the answer.
+
+**The null experiment.** `array_set_unchecked/4`'s `wrote(H, ?ELEM_WORDS)`
+removed altogether, which is the ceiling on what any block scheme could
+recover. Ten thousand elements, load average 4, two runs:
+
+| arm | charged | uncharged |
+| --- | ---: | ---: |
+| `array.fill` sparse, reductions | 6.0 | 5.0 |
+| `array.fill` dense, reductions | 6.0 | 5.0 |
+| `array.copy`, reductions | 7.0 | 6.0 |
+| words reclaimed, every arm | unchanged | unchanged |
+
+Exactly one reduction an element, and no allocation at all.
+
+**And in time**, from `store_primitives`, which now has the row it was missing:
+
+| operation | ns/op net |
+| --- | ---: |
+| `ets:lookup_element` | 37.0 |
+| `ets:lookup`, whole row | 36.3 |
+| **`atomics:add_get`** | **4.8** |
+| null arm, the loop alone | 2.8 gross |
+
+The primitives table in this file had `atomics:get` at 4.66 to 4.93 and
+`atomics:put` at 5.77 and nothing for the read-modify-write the mutation
+counter actually is, so its cost could be reasoned about and not read. It is
+4.8, against the two table operations beside it at about 36 each: **the charge
+is about 6% of a bulk element.**
+
+The two views disagree in proportion, 17% of the reductions against 6% of the
+time, and the time is the one to believe here. A reduction is not proportional
+to nanoseconds and an ETS BIF is the case where they come apart furthest.
+
+Six per cent, against a design that needs the keeper to reserve prospective
+words rather than only check them. `ATTEMPTS.md` has the three ways the cheap
+version is wrong and why the correct one waits.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3182,3 +3182,38 @@ time. The three together are 57% of the reductions a copied element cost.
 
 The fill arms do not move, which is what says the change is where it claims to
 be: sparse stays at 7.8 reductions an element and dense at 7.8.
+
+## Direction decides an overlapping array.copy, so nothing is materialised
+
+`array_copy/6` read the whole source into a list before writing any of it, so
+that an overlapping copy behaved as though an intermediate copy were taken.
+That is one way to get the answer and it costs a list per copy. The other is
+the direction: downwards when the destination starts later inside the same
+array, upwards everywhere else, which is what `memmove` does and what the
+specification's "as if an intermediate copy" means.
+
+Ten thousand elements, two runs each:
+
+| | `f94e5b4` | this commit |
+| --- | ---: | ---: |
+| reductions per element | 8.6, 8.6 | **7.0, 7.0** |
+| words reclaimed per element | 11.8, 11.9 | **9.9, 9.4** |
+
+Times are not quoted: the box went from load 5 to load 14 between the two
+measurements and the column is unreadable across that.
+
+**It cost 0.4 reductions an element before `elem_at/2` was inlined**, at 9.0
+against the 8.6 it started from, which is more than the lookup it wraps. As a
+loop body it was inline already; pulling it into a function so both directions
+could share it is what put the call there. `-compile({inline, ...})` is the
+same answer `wrote/2` and `crossed/2` needed, and for the same reason.
+
+No new case pins this. Commit `f94e5b4` keeps a full snapshot, so it is already
+right for every overlap direction and a new overlap case would pass against it,
+which is the vacuous test AGENTS.md forbids. `testsuite/array_copy.wast` is
+what pins it: 35 assertions, 0 fail, 0 skip, two of them the overlap cases,
+inside the 65,481 the floor asserts.
+
+A copied element is now cheaper than a filled one, 7.0 against `array.fill`
+sparse at 7.8, which is the next thing to look at: the fill loop still runs
+`lists:foreach` over a `lists:seq`.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3217,3 +3217,38 @@ inside the 65,481 the floor asserts.
 A copied element is now cheaper than a filled one, 7.0 against `array.fill`
 sparse at 7.8, which is the next thing to look at: the fill loop still runs
 `lists:foreach` over a `lists:seq`.
+
+## The partial fill loop stops building a list of the indices it will use
+
+`fill_each/5` was `lists:foreach` over `lists:seq(0, Len - 1)`: one cons cell
+per element of a list nothing outside the loop ever sees, and a fun call on top
+of each write. It counts down instead.
+
+Ten thousand elements, load average 7, two runs each:
+
+| | `ca58eb5` | this commit |
+| --- | ---: | ---: |
+| `array.fill` sparse, reductions | 7.8, 7.8 | **6.0, 6.0** |
+| `array.fill` sparse, words reclaimed | 8.8, 8.6 | **6.7, 6.8** |
+| `array.fill` dense, reductions | 7.8, 7.8 | **6.0, 6.0** |
+| `array.fill` dense, words reclaimed | 8.1, 8.1 | **6.0, 6.1** |
+| `array.copy`, the control | 7.0 | 7.0 |
+
+`array.copy` not moving is what says this landed where it claims to: it shares
+`array_set_unchecked/4` with the fill and nothing else.
+
+### Where the bulk array path stands
+
+Reductions per element written, ten thousand elements, across the four commits:
+
+| | `16c109e` baseline | now | change |
+| --- | ---: | ---: | ---: |
+| `array.copy` | 19.9 | **7.0** | **-65%** |
+| `array.fill` sparse | 7.8 | **6.0** | **-23%** |
+| `array.fill` dense | 7.8 | **6.0** | **-23%** |
+| `array.fill` whole | 0.0 | 0.0 | the row-update shortcut |
+
+What is left in an element is two ETS operations and one `atomics:add_get`.
+Whether the atomic is worth removing is the next measurement, not the next
+change: see the bulk plan's fourth step for why a block reservation as it
+stands would be a false refusal waiting to happen.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3096,3 +3096,58 @@ number the whole branch has to keep flat:
 | --- | ---: | ---: |
 | a loop iteration with a memory store | 44.035 | 44.035 |
 | a short call | 84.811 -- 84.826 | 84.794 |
+
+## The bulk array arm could not fail, and now reports allocation
+
+`bulk_array_ops` asserted `{ok, []}` on `alloc` and then handed `wasm:call/3`
+to `best_ms/1`, which discards the result. A call refused on its first
+instruction was timed exactly as a call that filled the array was, and reported
+a much better number. Checking the destination afterwards would not have caught
+it either: the fixture filled the whole array with 7, which the shortcut turns
+into a new default, then measured a partial fill writing 7 over 7, and a copy
+whose destination equalled its source from the second round on.
+
+The arm now writes a value the destination does not already hold, over an
+interior range with a sentinel at each end, and reads it back through
+`wasm:get_global/2` and `wasm_heap:array_get/3` outside the timed region. Three
+injections, each reverted after:
+
+| what was skipped | what the arm said |
+| --- | --- |
+| the `array_fill` clause's call into `wasm_heap` | `{array_not_written, src, 0, 7, 0}` |
+| `fill_each/5`, the partial-fill loop alone | `{array_not_written, src, 1, 7, 0}` |
+| the writes in the `array_copy` clause | `{array_not_written, dst, 0, 7, 0}` |
+
+The second one is the sharpest: it gets past the whole-array arm and is caught
+at index 1, which is what the interior range and its two sentinels are for. A
+range ending at the array boundary would hide a loop writing an invisible row
+at `Len`.
+
+Sparse and dense are separate arms because they are different operations: one
+creates an element row per index and the other replaces one.
+
+### Reductions, not nanoseconds
+
+Two runs of the arm, ten thousand elements, load average 4:
+
+| arm | ns | reductions | words reclaimed |
+| --- | ---: | ---: | ---: |
+| `array.fill` whole | 0.5, 0.6 | 0.0 | 0.0 |
+| `array.fill` sparse | 185.6, 184.2 | 7.8, 7.9 | 8.8 |
+| `array.fill` dense | 160.5, 163.1 | 7.8 | 8.1, 8.0 |
+| `array.copy` | 282.4, 294.5 | 19.9 | 18.4, 18.8 |
+
+The time column moves 4% between two runs of the same code at the same load,
+and at a hundred elements it moves 60%. The reduction column does not move.
+Every claim about this path comes from that column, with the time beside it for
+scale.
+
+Reclaimed words come from `erlang:statistics(garbage_collection)` around an
+isolated worker with a forced collection either side. That counter is
+node-wide, so the figure is only readable on a quiet box. Neither reductions
+nor a collection count would say it alone: a ten-thousand element temporary
+list can fit in the heap the process already has and provoke no collection at
+all.
+
+Per element means per element *written*, so an interior fill divides by
+`Len - 2` and not by the array's length.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3294,7 +3294,7 @@ Six per cent, against a design that needs the keeper to reserve prospective
 words rather than only check them. `ATTEMPTS.md` has the three ways the cheap
 version is wrong and why the correct one waits.
 
-## What `uns(64, _)` costs: nothing on a comparison, 43x on a shift
+## What `uns(64, _)` costs: about 3.5 nanoseconds, and not worth a change
 
 `wasm_core:uns(64, E)` is `band 16#FFFFFFFFFFFFFFFF`, a literal past the 60-bit
 immediate range, applied to values already held in `[-2^63, 2^63)`. It is
@@ -3303,52 +3303,48 @@ reached by `i64.shr_u` and by every unsigned 64-bit comparison, and **not** by
 call to `wasm_exec:op2/3`.
 
 Each unsigned form measured next to its signed twin, which is the same
-instruction without the mask. Generated code, load average 4, `perinstr`:
+instruction without the mask, so the *difference* between a pair is what the
+mask costs. Generated code, `perinstr`, interleaved:
 
-| snippet | ns/snippet |
-| --- | ---: |
-| `i64.lt_s`, small | 0.99 |
-| `i64.lt_u`, small | 1.05 |
-| `i64.lt_s`, high bit | 0.98 |
-| `i64.lt_u`, high bit | 0.85 |
-| `i64.ge_s`, high bit | 1.12 |
-| `i64.ge_u`, high bit | 0.87 |
-| `i64.shr_s`, small | 0.64 |
-| `i64.shr_u`, small | 0.55 |
-| `i64.shr_s`, high bit | 0.74 |
-| **`i64.shr_u`, high bit** | **30.71** |
+| pair | signed | unsigned | the mask |
+| --- | ---: | ---: | ---: |
+| `i64.lt`, small | 0.99 | 1.05 | nothing |
+| `i64.lt`, high bit | 0.98 | 0.85 | nothing |
+| `i64.ge`, high bit | 1.12 | 0.87 | nothing |
+| `i64.shr`, high bit, by 1 | 26.05, 27.14 | 30.16, 30.17 | **~3.5 ns** |
+| `i64.shr`, high bit, by 47 | 0.42, 0.64 | 0.61, 0.67 | ~0.1 ns |
 
-Three runs of the last row: 30.71, 31.18, 30.81, against 0.71 to 0.74 for its
-signed twin. Everything else is a wash.
+Nothing here is worth a change, and one was attempted anyway. See
+`ATTEMPTS.md`: routing `i64.shr_u` through a three-clause case that avoids the
+mask for the two cases that can avoid it made every measured case **two to
+three times slower**, because the case is what stops the SSA pass doing better
+than any of it.
 
-**The comparisons are free and the shift is not**, and the shape says why:
-`i64.shr_u` is `wrap(64, bsr(uns(64, A), _))`, so a negative `A` becomes a
-bignum in `uns/2` and then goes through `wrap/2`'s `band`, `bxor` and `-`,
-which are three more. A comparison masks and then compares once.
+The shift rows are large for both signs because the snippet accumulates its
+results, and a value shifted right by one is around 2^62, which puts the
+accumulating `i64.add` on `wrap_sum/2`'s slow clause. That is the snippet, not
+the shift. It is why the pair matters and neither number does.
 
-So the change worth making is to `i64.shr_u` and not to `uns/2` in general, and
-it is not made here. The cheap form has to case on the shift amount: the
-identity that avoids the bignum is `(A bsr S) + (1 bsl (64 - S))` for a
-negative `A`, and `1 bsl (64 - S)` is itself past the immediate range until `S`
-reaches 5. That is a real piece of code generation with a silent failure mode,
-it is not the bulk array path this branch is about, and it now has a number to
-justify it.
+### It took four tries to make this probe measure anything
 
-### It took three tries to make the probe measure anything
+Every row read 0.00 twice, then the two shift rows disagreed by 43x, and only
+the fourth version measured the instruction. Each failure was a different way
+for the optimiser to be right about code that was not doing anything:
 
-Every row read 0.00 twice before it read 30.71, and each time for a different
-reason. This is the failure ATTEMPTS.md names, met three ways in one afternoon:
-
-1. **`(drop (i64.lt_u ...))`.** A computation whose result is dropped is dead
-   and the SSA pass deletes it.
+1. **`(drop (i64.lt_u ...))`.** A computation whose result is dropped is dead.
 2. **A loop-invariant operand.** `(i64.lt_u (local.get $h) (i64.const 5))` with
-   `$h` set before the loop is hoisted out of it entirely.
+   `$h` set before the loop is hoisted out of it.
 3. **Repeated `local.set $t`.** Forty independent writes to one local are
-   thirty-nine dead stores; only the last survives.
+   thirty-nine dead stores.
+4. **Variation the instruction discards.** Xoring the loop counter into the low
+   bits varies bits 0 to 17, and a shift of 47 throws them away, so the
+   expression was loop-invariant again. This one was the dangerous one: it did
+   not read 0.00, it read *0.74 for the signed row and 30.71 for the unsigned
+   one*, and that 43x was reported as a finding before the fourth version
+   showed the pair is 26.05 against 30.16.
 
-The fix is what `i32.add` had been doing all along, which is why it was the row
-that reported a number while `i32.shl` reported zero: accumulate into the local
-you read, and xor one operand with the loop counter. `run_case/3` now prints
-`<- eliminated, or below the noise floor` beside any row under 0.05 ns, so the
-next reader does not have to notice a zero. It fires on four rows that were
-already in the file.
+The fix is what `i32.add` had been doing all along: accumulate into the local
+you read, and vary a part of the operand the instruction actually keeps.
+`run_case/3` prints `<- eliminated, or below the noise floor` beside any row
+under 0.05 ns, which catches the first three but not the fourth. Nothing
+catches the fourth except reading the pair.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3348,3 +3348,42 @@ you read, and vary a part of the operand the instruction actually keeps.
 `run_case/3` prints `<- eliminated, or below the noise floor` beside any row
 under 0.05 ns, which catches the first three but not the fourth. Nothing
 catches the fourth except reading the pair.
+
+## Four rows of the price table had stopped measuring anything
+
+`PERF.md`'s compiled price table above has `i32.mul` at 2.45 ns, `i32.shl` at
+1.95, `i64.shl` at 24.99 and `f64.convert_i32_u` at 4.73. Re-running the arm
+that produced them now gives 0.02, 0.00, -0.01 and -0.00. The snippets had not
+changed. The compile quality default has moved to `full` since they were taken,
+and `full` collapses forty shifts of one local into one shift and drops
+thirty-nine stores to a local nothing reads.
+
+Each snippet now xors the loop counter into its operand, or accumulates, so no
+copy is the same computation as the one before it. Two passes, load average 10:
+
+| snippet | ns | what else is in it |
+| --- | ---: | --- |
+| `i32.xor`, the null arm | 0.52, 0.53 | the loop, and the xor |
+| `i32.add`, for scale | 0.69 | nothing |
+| `i32.mul` | 2.71, 2.97 | the xor |
+| `i32.shl` | 2.99, 2.95 | the xor |
+| **`i64.shl`** | **30.97, 28.90** | the xor, and an `i64.extend_i32_u` |
+| `f64.convert_i32_u` | 10.29, 10.47 | an `f64.add`, which is 6.57 |
+
+Net of what each carries, that is about 2.3 for `i32.mul`, 2.4 for `i32.shl`
+and 3.7 for `f64.convert_i32_u`, against the 2.45, 1.95 and 4.73 the table
+records. The rows reproduce, which is what says the zeros were the artefact and
+not a change in the runtime.
+
+**`i64.shl` does not reproduce so much as persist: about 29 ns against
+`i32.shl`'s 2.4, a 12x gap.** It is the last of the i64 constructs the 60-bit
+work did not reach, and for a reason: `wrap(64, bsl(A, Sh))` shifts *before* it
+masks, so the intermediate is up to 2^126 whatever the answer turns out to be.
+Masking first, `(A band (2^64-1 bsr Sh)) bsl Sh`, keeps the intermediate inside
+64 bits but needs a bignum literal of its own.
+
+That is a real number and it is not acted on here. The `i64.shr_u` attempt
+recorded in `ATTEMPTS.md` was also a correct rewrite of a genuinely masked
+path, and it was two to three times slower, because a guarded form stops the
+SSA pass doing better than the guard. Anything done to `i64.shl` gets measured
+against that expectation, interleaved, before it is believed.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3151,3 +3151,34 @@ all.
 
 Per element means per element *written*, so an interior fill divides by
 `Len - 2` and not by the array's length.
+
+## The array.copy loop moves next to the accounting
+
+`wasm_exec`'s `array_copy` clause built three lists per copy and did a table
+lookup per element that the range check had already answered:
+`lists:seq(0, Len - 1)`, a `Vals` list from it, and then a third list of index
+pairs inside `write_elements/4` through `lists:enumerate/2`. Every read went
+through `array_get/3`, which calls `array_len/2`, which is
+`ets:lookup_element` on the object table, once per element, to re-check a range
+`check_array_range/4` had just checked.
+
+`wasm_heap:array_copy/6` holds the loop instead, beside the accounting it has
+to go through anyway. It reads the source's default *once*: most elements of an
+array have no row of their own, so a copy out of a defaulted array was that
+second lookup and nothing else.
+
+Ten thousand elements, load average 5, two runs each:
+
+| | `858b2fe` | this commit |
+| --- | ---: | ---: |
+| reductions per element | 19.9, 19.9 | **8.6, 8.6** |
+| words reclaimed per element | 18.4, 18.8 | **11.8, 11.9** |
+| ns per element | 282.4, 294.5 | 201.3, 193.5 |
+
+**This is not an isolated measurement of the table lookup**, and it cannot be
+made into one without exporting the raw getter for one commit and making it
+private again in the next. Moving the loop removes the two lists at the same
+time. The three together are 57% of the reductions a copied element cost.
+
+The fill arms do not move, which is what says the change is where it claims to
+be: sparse stays at 7.8 reductions an element and dense at 7.8.

--- a/test/wasm_gc_bench_SUITE.erl
+++ b/test/wasm_gc_bench_SUITE.erl
@@ -436,6 +436,12 @@ store_primitives(_Config) ->
             {"ets:update_element",
              fun(I) -> ets:update_element(Tab, I, {4, {I, null}}) end},
             {"atomics mark bit", fun(I) -> mark_bit(Bits, I) end},
+            %% What every element of a bulk array operation pays to be counted.
+            %% The primitives table in `PERF.md' had `atomics:get' and
+            %% `atomics:put' and nothing for the read-modify-write the mutation
+            %% counter is, so the cost of that counter could only be reasoned
+            %% about and not read.
+            {"atomics:add_get", fun(_) -> atomics:add_get(Bits, 1, 1) end},
             {"map live-set insert", fun(I) -> live_insert(I) end}],
     ct:log("null arm (loop only): ~7.1f ns/op", [Null]),
     lists:foreach(

--- a/test/wasm_gc_bench_SUITE.erl
+++ b/test/wasm_gc_bench_SUITE.erl
@@ -39,6 +39,15 @@
 %% (ref null $s), where $s is type index 0 in each module below.
 -define(REF0, [16#63, 0]).
 
+%% Two fill values, so a round always writes something the array does not
+%% already hold and a skipped operation cannot look like a done one. Neither is
+%% 0, which is what `array.new_default' leaves and what the sentinels stay at.
+-define(FILL_A, 7).
+-define(FILL_B, 8).
+
+%% How many rounds every measurement here takes the best of.
+-define(ROUNDS, 5).
+
 %% Empty on purpose. Every case here logs a number and asserts nothing, so a
 %% plain `rebar3 ct' would spend minutes on measurements that cannot fail and
 %% would report them as passing tests. They live in a group instead, which is
@@ -240,26 +249,144 @@ field_index_cost(_Config) ->
            [Per(~"first") - Empty, Per(~"last") - Empty, Empty]),
     ok = wasm:destroy(Inst).
 
-%% `array.fill' and `array.copy' at growing lengths, reported per element.
+%% `array.fill' and `array.copy' at growing lengths, per element.
 %%
-%% Per-element cost that grows with length is the signature of a quadratic, and
-%% `array.copy' materialises its source as a list and then indexes it with
-%% `lists:nth/2' inside the fold.
+%% Four arms, and every one of them can fail. The version this replaces handed
+%% `wasm:call/3' to `best_ms/1', which throws the result away, so a call
+%% refused on its first instruction was timed as though it had filled the
+%% array. Checking the destination afterwards would not have caught it either:
+%% the fixture filled the whole array with 7, which the shortcut turns into a
+%% new default, and then measured a partial fill writing 7 over 7, and a copy
+%% whose destination equalled its source from the second round on. Every arm
+%% below writes a value the destination does not already hold and checks it
+%% outside the timed region.
+%%
+%% Sparse and dense are separate because they are different operations: the
+%% first creates an element row per index and the second replaces one. Step 4
+%% of the bulk plan is about the difference between them.
 bulk_array_ops(_Config) ->
-    lists:foreach(
-      fun(Len) ->
-          {ok, Inst} = instantiate(array_module()),
-          {ok, []} = wasm:call(Inst, ~"alloc", [Len]),
-          Fill = best_ms(fun() -> wasm:call(Inst, ~"fill", [Len]) end),
-          Part = best_ms(fun() -> wasm:call(Inst, ~"fill_part", [Len]) end),
-          Copy = best_ms(fun() -> wasm:call(Inst, ~"copy", [Len]) end),
-          ct:log("~6w elements: array.fill whole ~8.1f | part ~8.1f | "
-                 "array.copy ~8.1f ns/element",
-                 [Len, Fill * 1000000 / Len, Part * 1000000 / Len,
-                  Copy * 1000000 / Len]),
-          ok = wasm:destroy(Inst)
-      end, [100, 1000, 10000]),
+    lists:foreach(fun bulk_array_len/1, [100, 1000, 10000]),
     ok.
+
+bulk_array_len(Len) ->
+    Alloc = fun(I) -> called(I, ~"alloc", [Len]) end,
+    Part = fun(V) -> fun(I) -> called(I, ~"fill_part", [Len, V]) end end,
+    Whole = fun(V) -> fun(I) -> called(I, ~"fill", [Len, V]) end end,
+    %% The whole-array fill is the constant-time row update, so it is reported
+    %% for the contrast and not because there is anything in it to remove.
+    W = arm(Alloc, Whole(?FILL_A), whole_is(Len, ?FILL_A)),
+    %% Interior, so index 0 and index `Len - 1' are sentinels the fill must not
+    %% touch. A range ending at the boundary hides an off-by-one that writes an
+    %% invisible row at `Len'.
+    S = arm(Alloc, Part(?FILL_A), part_is(Len, ?FILL_A)),
+    D = arm(fun(I) -> Alloc(I), (Part(?FILL_A))(I) end,
+            Part(?FILL_B), part_is(Len, ?FILL_B)),
+    C = arm(fun(I) -> Alloc(I), (Whole(?FILL_A))(I) end,
+            fun(I) -> called(I, ~"copy", [Len]) end, copy_is(Len, ?FILL_A)),
+    log_arm(Len, "array.fill whole    ", Len, W),
+    log_arm(Len, "array.fill sparse   ", Len - 2, S),
+    log_arm(Len, "array.fill dense    ", Len - 2, D),
+    log_arm(Len, "array.copy          ", Len, C).
+
+%% The denominator is what the operation actually wrote, which for an interior
+%% fill is two fewer than the array is long.
+log_arm(Len, What, N, #{ns := Ns, reds := Reds, words := Words, gcs := GCs}) ->
+    ct:log("~6w elements: ~s ~8.1f ns | ~8.1f reductions | "
+           "~8.1f words reclaimed per element (~w collections)",
+           [Len, What, Ns / N, Reds / N, Words / N, GCs]).
+
+%% One arm. `Setup' runs before every round and is not timed, `Op' is what is
+%% timed, `Check' runs after it and fails the case when the operation did not
+%% happen.
+%%
+%% In a process of its own, because repeating a real module in one process
+%% makes it bimodal on collection time, and because `statistics(
+%% garbage_collection)' counts the whole node: a round has to be the only thing
+%% this process is doing, and the box has to be quiet, which
+%% `bench/paths/README.md' asks for anyway.
+%% Monitored, not plain `spawn': `Check' fails by raising, in the worker, and
+%% without the monitor the only symptom the case has is the receive timing out
+%% five minutes later under a reason that says nothing.
+arm(Setup, Op, Check) ->
+    Parent = self(),
+    {Pid, Mon} =
+        spawn_monitor(fun() ->
+                          {ok, Inst} = instantiate(array_module()),
+                          Rounds = [round_of(Inst, Setup, Op, Check)
+                                    || _ <- lists:seq(1, ?ROUNDS)],
+                          ok = wasm:destroy(Inst),
+                          Parent ! {self(), fastest(Rounds)}
+                      end),
+    receive
+        {Pid, R} -> erlang:demonitor(Mon, [flush]), R;
+        {'DOWN', Mon, process, Pid, Why} -> ct:fail(Why)
+    after 300000 -> ct:fail(bulk_array_arm_timeout)
+    end.
+
+round_of(Inst, Setup, Op, Check) ->
+    ok = Setup(Inst),
+    %% The setup's garbage goes before the counters and the operation's after
+    %% them, so the reclaimed words bracket the timed region and nothing else.
+    %% Neither reductions nor a collection count would say this on its own: a
+    %% ten-thousand element temporary list can fit in the heap the process
+    %% already has and provoke no collection at all.
+    _ = erlang:garbage_collect(),
+    {GC0, Words0, _} = erlang:statistics(garbage_collection),
+    {reductions, R0} = erlang:process_info(self(), reductions),
+    T0 = erlang:monotonic_time(nanosecond),
+    ok = Op(Inst),
+    T1 = erlang:monotonic_time(nanosecond),
+    {reductions, R1} = erlang:process_info(self(), reductions),
+    _ = erlang:garbage_collect(),
+    {GC1, Words1, _} = erlang:statistics(garbage_collection),
+    ok = Check(Inst),
+    #{ns => T1 - T0, reds => R1 - R0,
+      words => Words1 - Words0, gcs => GC1 - GC0}.
+
+%% The fastest round with its own counters, rather than the minimum of each
+%% column: reductions from one round beside a time from another describe a run
+%% that did not happen.
+fastest(Rounds) ->
+    hd(lists:sort(fun(#{ns := A}, #{ns := B}) -> A =< B end, Rounds)).
+
+called(Inst, Name, Args) ->
+    {ok, []} = wasm:call(Inst, Name, Args),
+    ok.
+
+%% What each arm asserts afterwards. Read back through `wasm:get_global/2' and
+%% `wasm_heap:array_get/3', so a check cannot pass on a row the runtime would
+%% not return.
+whole_is(Len, V) -> fun(I) -> elements_are(I, ~"src", 0, Len, V) end.
+
+copy_is(Len, V) -> fun(I) -> elements_are(I, ~"dst", 0, Len, V) end.
+
+part_is(Len, V) ->
+    fun(I) ->
+        %% Both ends, so an overrun in either direction is caught.
+        ok = element_is(I, ~"src", 0, 0),
+        ok = element_is(I, ~"src", Len - 1, 0),
+        elements_are(I, ~"src", 1, Len - 2, V)
+    end.
+
+elements_are(Inst, Global, Start, N, V) ->
+    Ref = global(Inst, Global),
+    H = wasm_instance:heap(Inst),
+    case [I || I <- lists:seq(Start, Start + N - 1),
+               wasm_heap:array_get(H, Ref, I) =/= V] of
+        [] -> ok;
+        [I | _] -> ct:fail({array_not_written, Global, I, V,
+                            wasm_heap:array_get(H, Ref, I)})
+    end.
+
+element_is(Inst, Global, I, V) ->
+    case wasm_heap:array_get(wasm_instance:heap(Inst), global(Inst, Global), I) of
+        V -> ok;
+        Other -> ct:fail({sentinel_overwritten, Global, I, V, Other})
+    end.
+
+global(Inst, Name) ->
+    {ok, [Ref]} = wasm:get_global(Inst, Name),
+    Ref.
 
 %% How much BEAM heap the collecting process grows by while collecting.
 %%
@@ -322,8 +449,6 @@ store_primitives(_Config) ->
     ok.
 
 %%% ---------------------------------------------------------------- timing ---
-
--define(ROUNDS, 5).
 
 %% Minimum of several rounds. A single sample of anything on this box is
 %% worthless: repeated runs of the *same* arm span more than 3x.
@@ -540,24 +665,30 @@ countdown() -> <<16#20, 0, 16#41, 1, 16#6B, 16#22, 0, 16#0D, 0>>.
 %% ```
 array_module() ->
     Types = wasm_asm:section(
-              1, [wasm_asm:uleb(2),
+              1, [wasm_asm:uleb(3),
                   [16#5E, ?I32, 1],
-                  [16#60, wasm_asm:uleb(1), ?I32, wasm_asm:uleb(0)]]),
+                  [16#60, wasm_asm:uleb(1), ?I32, wasm_asm:uleb(0)],
+                  [16#60, wasm_asm:uleb(2), ?I32, ?I32, wasm_asm:uleb(0)]]),
     Alloc = <<16#20, 0, ?FB, 7, 0, 16#24, 0,
               16#20, 0, ?FB, 7, 0, 16#24, 1, 16#0B>>,
-    Fill = <<16#23, 0, 16#41, 0, 16#41, 7, 16#20, 0, ?FB, 16, 0, 16#0B>>,
-    %% From index 1, so it cannot become a new default and has to write every
-    %% element. Without this arm the benchmark would only ever measure the
-    %% whole-array shortcut.
-    Part = <<16#23, 0, 16#41, 1, 16#41, 7,
-             16#20, 0, 16#41, 1, 16#6B, ?FB, 16, 0, 16#0B>>,
+    %% `(len, v)'. The whole array, which is the row-update shortcut.
+    Fill = <<16#23, 0, 16#41, 0, 16#20, 1, 16#20, 0, ?FB, 16, 0, 16#0B>>,
+    %% `(len, v)'. From index 1 for `len - 2', so it cannot become a new
+    %% default, it has to write every element, and index 0 and index `len - 1'
+    %% are sentinels an off-by-one in either direction disturbs. Without this
+    %% arm the benchmark would only ever measure the whole-array shortcut.
+    Part = <<16#23, 0, 16#41, 1, 16#20, 1,
+             16#20, 0, 16#41, 2, 16#6B, ?FB, 16, 0, 16#0B>>,
     Copy = <<16#23, 1, 16#41, 0, 16#23, 0, 16#41, 0, 16#20, 0,
              ?FB, 17, 0, 0, 16#0B>>,
     wasm_asm:module(
       [Types,
-       wasm_asm:func_section([1, 1, 1, 1]),
+       wasm_asm:func_section([1, 2, 1, 2]),
        wasm_asm:global_section([{?REF0, true, <<16#D0, 0>>},
                                 {?REF0, true, <<16#D0, 0>>}]),
+       %% The two globals are exported so a check can read the arrays back
+       %% through the runtime rather than reaching into the tables.
        wasm_asm:export_section([{~"alloc", 0, 0}, {~"fill", 0, 1},
-                                {~"copy", 0, 2}, {~"fill_part", 0, 3}]),
+                                {~"copy", 0, 2}, {~"fill_part", 0, 3},
+                                {~"src", 3, 0}, {~"dst", 3, 1}]),
        wasm_asm:code_section([Alloc, Fill, Copy, Part])]).


### PR DESCRIPTION
Three of the six items an exploration proposed were already done: atomic keeper
reconciliation shipped in 0.2.0, `wasm_code_cache` is the artifact cache, and
the 60-bit immediate work took `i64.add` from 26.40 ns to 0.48. This is the one
that was open.

Reductions per element written, ten thousand elements:

| | before | after |
| --- | ---: | ---: |
| `array.copy` | 19.9 | 7.0 |
| `array.fill` sparse | 7.8 | 6.0 |
| `array.fill` dense | 7.8 | 6.0 |

The first commit is why any of those numbers mean anything: `bulk_array_ops`
timed `wasm:call/3` through a helper that discards the result, and the fixture
wrote 7 over 7, so a refused call reported a better number than one that did
the work. It now writes a value the destination does not hold, over an interior
range with a sentinel at each end, and three separate fault injections were
seen to fail it.

Two steps did not become changes:

- **Block accounting.** Deleting the per-element charge outright is worth one
  reduction an element and no allocation, and `atomics:add_get` is 4.8 ns
  against the two table operations beside it at about 36 each. Six per cent
  does not buy the keeper reserve/commit/abort a correct version needs, and
  `ATTEMPTS.md` records the three ways the cheap version is wrong.
- **`uns(64, _)`.** Read as signed/unsigned pairs, the mask is worth about
  3.5 ns on a shift and nothing at all on a comparison. An earlier commit in
  this branch reported 43x; the last commit corrects it. That reading came from
  a probe whose counter varied bits the shift discards, so the signed row was
  hoisted out of the loop and the unsigned one was not. Avoiding the mask with
  a case on the shift count is correct and two to three times slower, and is in
  `ATTEMPTS.md` rather than in the generator.

435 cases, lint, xref and dialyzer pass. `array_copy.wast` runs 35 assertions,
0 fail 0 skip, which is what pins the direction-aware copy.