### PR TITLE
Make the compiled tier reach a large guest, and turn its refusals into values

### DIFF
--- a/bench/paths/adopt.erl
+++ b/bench/paths/adopt.erl
@@ -1,0 +1,128 @@
+-module(adopt).
+-moduledoc """
+Whether a one-call guest can ever reach generated code.
+
+`wasm_jit:maybe_adopt/3` says a call that finds nothing resident sets an ask,
+interprets, and the module is adopted *on a later call*. Every `wasm32-wasi`
+command-line program is one call, `_start`, so the question is whether a second
+*instance* in the same emulator picks up what the first one asked for.
+
+This watches rather than assumes. It prints `wasm_jit:counts/0` after every
+step, so `compiled` and `entered` say what happened instead of a wall time
+being read as evidence:
+
+    erlc -I _build/default/lib -o bench/paths bench/paths/adopt.erl
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run adopt main <guest.wasm> <script-dir> [seconds] [cache-dir]
+
+Output is written as it happens. Do not pipe it through `tail`, which buffers
+until exit and hides exactly the progress this exists to show.
+""".
+
+-export([main/1]).
+
+-define(REQUEST, <<"{\"name\": \"ada\"}\n">>).
+
+main([Guest, Dir]) -> main([Guest, Dir, "180", "", "load"]);
+main([Guest, Dir, Secs]) -> main([Guest, Dir, Secs, "", "load"]);
+main([Guest, Dir, Secs, Cache]) -> main([Guest, Dir, Secs, Cache, "load"]);
+main([Guest, Dir, Secs, Cache, How]) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    Cache =:= "" orelse application:set_env(wasm, code_cache_dir, Cache),
+    {ok, Bin} = file:read_file(Guest),
+    %% Three ways in. `load' puts the module in `persistent_term'; `compile'
+    %% keeps it on this process's heap and, with no identity,
+    %% `wasm_code_cache:key/6' refuses it, so nothing it compiles is ever kept.
+    %% `hashed' is the interesting one: on the heap like `compile', and named by
+    %% its content hash like `load', which is the pair the cache actually needs.
+    {ok, Mod} =
+        case How of
+            "load" -> wasm:load(Bin);
+            "compile" -> wasm:compile(Bin);
+            "hashed" ->
+                wasm:compile(Bin, #{identity => {sha256, crypto:hash(sha256, Bin)}})
+        end,
+    io:format("module in by ~s~n", [How]),
+    say("start", 0),
+
+    %% One call, which is all a `_start' guest ever makes. `after_call/2' runs
+    %% inside `wasm:call/3' at depth 0, so the ask is raised here and not lost
+    %% when this process moves on.
+    {T1, R1} = run(Mod, Dir),
+    io:format("call 1: ~w ms, reply ~p~n", [T1, R1]),
+    say("after call 1", 0),
+
+    %% Watch for the compiler. If `compiled' never moves, nothing was ever
+    %% queued and the disk cache can never be filled by this shape of workload.
+    Waited = watch(list_to_integer(Secs)),
+
+    %% A fresh instance of the same module: this is the one that could adopt.
+    {T2, R2} = run(Mod, Dir),
+    io:format("call 2: ~w ms, reply ~p~n", [T2, R2]),
+    say("after call 2", Waited),
+
+    io:format("~ncache dir holds ~w file(s)~n",
+              [length(filelib:wildcard(filename:join(
+                        application:get_env(wasm, code_cache_dir, "/nonexistent"),
+                        "*.beam")))]),
+    init:stop().
+
+%% Poll rather than sleep, so the moment compilation lands is visible.
+watch(Secs) ->
+    watch(Secs * 4, 0).
+
+watch(0, N) ->
+    io:format("gave up after ~w s~n", [N div 4]),
+    N div 4;
+watch(Left, N) ->
+    timer:sleep(250),
+    case wasm_jit:counts() of
+        #{compiled := C} when C > 0 ->
+            io:format("compiled after ~w s~n", [(N + 1) div 4]),
+            (N + 1) div 4;
+        _ -> watch(Left - 1, N + 1)
+    end.
+
+say(When, _) ->
+    io:format("  ~-14s ~p~n", [When, wasm_jit:counts()]).
+
+run(Mod, Dir) ->
+    %% Both calls run in this process, so the stdin fun's "already sent" flag
+    %% has to be cleared or the second call reads end of file at once, exits in
+    %% milliseconds and reports no reply. That is a harness bug that reads
+    %% exactly like a 16x speedup.
+    _ = erase(sent), _ = erase(buf), _ = erase(line),
+    Wasi = #{args => argv(Dir),
+             dirs => [{~"/app", Dir, read}],
+             stdin => fun(_) -> once(?REQUEST) end,
+             stdout => fun(D) -> line(D) end,
+             stderr => fun(_) -> ok end},
+    {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi),
+                               #{max_memory_pages => 4096, compile => true,
+                                 compile_after => 1}),
+    T0 = erlang:monotonic_time(millisecond),
+    _ = wasm:call(I, ~"_start", []),
+    T = erlang:monotonic_time(millisecond) - T0,
+    ok = wasm:destroy(I),
+    {T, erase(line)}.
+
+argv(Dir) ->
+    case filelib:is_regular(filename:join(Dir, "worker.py")) of
+        true -> [~"python", ~"-u", ~"/app/worker.py"];
+        false -> [~"qjs", ~"/app/worker.js"]
+    end.
+
+once(Data) ->
+    case get(sent) of
+        undefined -> put(sent, true), {ok, Data};
+        true -> eof
+    end.
+
+line(Data) ->
+    B = <<(case get(buf) of undefined -> <<>>; X -> X end)/binary,
+          (iolist_to_binary(Data))/binary>>,
+    case binary:split(B, ~"\n") of
+        [L, Rest] -> put(line, L), put(buf, Rest);
+        [_] -> put(buf, B)
+    end,
+    ok.

--- a/bench/paths/allocwords.erl
+++ b/bench/paths/allocwords.erl
@@ -29,11 +29,41 @@ should be run on any machine before the numbers here are believed.
         -run allocwords main
 """.
 
--export([measure/1, measure/2, validate/0, main/1]).
+-export([measure/1, measure/2, measure/3, validate/0, main/1]).
 
 -doc "Run `F' in a fresh process and report what it allocated.".
 -spec measure(fun(() -> term())) -> map().
 measure(F) -> measure(F, 300000).
+
+-doc """
+As `measure/2`, with a setup that runs in the same process and outside the
+window.
+
+Some costs can only be moved out of a measurement by doing them first *in the
+process that will be measured*: the interpreter's lowered-IR cache is keyed on
+the instance and lives in the process dictionary, so pre-lowering has to happen
+there. Tracing starts once `Setup` has returned, so nothing it allocates is
+counted.
+""".
+-spec measure(fun(() -> term()), fun((term()) -> term()), timeout()) -> map().
+measure(Setup, Body, Timeout) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+                    receive go -> ok end,
+                    S = Setup(),
+                    %% Setup is done and untraced; ask for the window now.
+                    Parent ! {ready, self()},
+                    receive traced -> ok end,
+                    erlang:garbage_collect(),
+                    R = Body(S),
+                    erlang:garbage_collect(),
+                    Parent ! {done, self(), R}
+                end),
+    Pid ! go,
+    receive {ready, Pid} -> ok after Timeout -> erlang:error(setup_timeout) end,
+    erlang:trace(Pid, true, [garbage_collection]),
+    Pid ! traced,
+    collect(Pid, Timeout).
 
 -spec measure(fun(() -> term()), timeout()) -> map().
 measure(F, Timeout) ->
@@ -51,6 +81,9 @@ measure(F, Timeout) ->
                 end),
     erlang:trace(Pid, true, [garbage_collection]),
     Pid ! go,
+    collect(Pid, Timeout).
+
+collect(Pid, Timeout) ->
     Result = receive {done, Pid, R} -> R
              after Timeout -> erlang:error(measure_timeout)
              end,

--- a/bench/paths/allocwords.erl
+++ b/bench/paths/allocwords.erl
@@ -31,6 +31,11 @@ should be run on any machine before the numbers here are believed.
 
 -export([measure/1, measure/2, measure/3, validate/0, main/1]).
 
+%% Timestamped, because a run's GC *time* is the number the plan gates on and
+%% no counter carries it. Collections do not nest in one process, so a start
+%% and the end after it are one collection.
+-define(FLAGS, [garbage_collection, monotonic_timestamp]).
+
 -doc "Run `F' in a fresh process and report what it allocated.".
 -spec measure(fun(() -> term())) -> map().
 measure(F) -> measure(F, 300000).
@@ -61,7 +66,7 @@ measure(Setup, Body, Timeout) ->
                 end),
     Pid ! go,
     receive {ready, Pid} -> ok after Timeout -> erlang:error(setup_timeout) end,
-    erlang:trace(Pid, true, [garbage_collection]),
+    erlang:trace(Pid, true, ?FLAGS),
     Pid ! traced,
     collect(Pid, Timeout).
 
@@ -79,7 +84,7 @@ measure(F, Timeout) ->
                     erlang:garbage_collect(),
                     Parent ! {done, self(), R}
                 end),
-    erlang:trace(Pid, true, [garbage_collection]),
+    erlang:trace(Pid, true, ?FLAGS),
     Pid ! go,
     collect(Pid, Timeout).
 
@@ -93,26 +98,48 @@ collect(Pid, Timeout) ->
     receive {trace_delivered, Pid, Ref} -> ok end,
     %% No untrace: the process has already exited, and tracing a dead pid is a
     %% badarg rather than a no-op.
-    Ends = [I || {trace, _, K, I} <- drain(),
-                 K =:= gc_minor_end orelse K =:= gc_major_end],
-    report(Ends, Result).
+    Events = drain(),
+    %% The opening forced major is the boundary in the timing too, not only in
+    %% the words: drop its pair before summing.
+    report([{K, I} || {K, I, _} <- Events,
+                      K =:= gc_minor_end orelse K =:= gc_major_end],
+           us(gc_time(drop_pair(Events))), Result).
 
-report([], Result) ->
+%% One collection is a start and the end that follows it.
+gc_time(Events) -> gc_time(Events, 0).
+
+gc_time([{S, _, T0}, {E, _, T1} | Rest], Acc)
+  when (S =:= gc_minor_start orelse S =:= gc_major_start) andalso
+       (E =:= gc_minor_end orelse E =:= gc_major_end) ->
+    gc_time(Rest, Acc + (T1 - T0));
+gc_time([_ | Rest], Acc) -> gc_time(Rest, Acc);
+gc_time([], Acc) -> Acc.
+
+drop_pair([_, _ | Rest]) -> Rest;
+drop_pair(_) -> [].
+
+us(T) -> erlang:convert_time_unit(T, native, microsecond).
+
+report([], _GcUs, Result) ->
     #{allocated => 0, reclaimed => 0, collections => 0, result => Result,
       note => no_collections};
-report([Open | Rest], Result) ->
+report([{_, Open} | Rest], GcUs, Result) ->
     Live0 = live(Open),
-    Live1 = case Rest of [] -> Live0; _ -> live(lists:last(Rest)) end,
-    Reclaimed = lists:sum([w(I, wordsize) || I <- Rest]),
+    Live1 = case Rest of [] -> Live0; _ -> live(element(2, lists:last(Rest))) end,
+    Reclaimed = lists:sum([w(I, wordsize) || {_, I} <- Rest]),
     #{allocated => Reclaimed + Live1 - Live0,
       reclaimed => Reclaimed,
       live_before => Live0,
       live_after => Live1,
       collections => length(Rest),
+      minor => length([x || {gc_minor_end, _} <- Rest]),
+      major => length([x || {gc_major_end, _} <- Rest]),
+      gc_us => GcUs,
       %% Zero at both boundaries or the accounting has to explain them.
       mbuf => {w(Open, mbuf_size), case Rest of
                                        [] -> w(Open, mbuf_size);
-                                       _ -> w(lists:last(Rest), mbuf_size)
+                                       _ -> w(element(2, lists:last(Rest)),
+                                              mbuf_size)
                                    end},
       result => Result}.
 
@@ -123,7 +150,7 @@ w(Info, Key) -> proplists:get_value(Key, Info, 0).
 drain() -> drain([]).
 
 drain(Acc) ->
-    receive {trace, _, _, _} = T -> drain([T | Acc])
+    receive {trace_ts, _, Kind, Info, Ts} -> drain([{Kind, Info, Ts} | Acc])
     after 0 -> lists:reverse(Acc)
     end.
 

--- a/bench/paths/allocwords.erl
+++ b/bench/paths/allocwords.erl
@@ -1,0 +1,139 @@
+-module(allocwords).
+-moduledoc """
+How many heap words one process allocated, from its own collection trace.
+
+Use this instead of `erlang:statistics(garbage_collection)` for any question
+about a single process. That counter is node-wide: it reported no change from a
+`min_heap_size` floor while the process's own collections fell 51x, which is
+what sent an investigation down the wrong path for an afternoon.
+
+There is no per-process allocated-words counter, so this derives one. A
+`gc_minor_end` or `gc_major_end` event carries `wordsize`, the memory that
+collection reclaimed, so over a window bounded by a forced major at each end:
+
+    reclaimed = sum of `wordsize' over the end events inside the window
+    allocated = reclaimed + ending live words - starting live words
+
+with live words being `heap_size' + `old_heap_size'. The opening major is the
+boundary and is excluded, since what it reclaims belongs to whatever ran before;
+the closing one is included.
+
+Not by differencing consecutive `heap_size' values, which was the first draft
+and is wrong: it miscounts heap fragments, message buffers and generational
+movement, and a simple-list calibration passes anyway. `validate/0` is what
+says the estimator works, in both of the forms it has to get right, and it
+should be run on any machine before the numbers here are believed.
+
+    erlc -o bench/paths bench/paths/allocwords.erl
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run allocwords main
+""".
+
+-export([measure/1, measure/2, validate/0, main/1]).
+
+-doc "Run `F' in a fresh process and report what it allocated.".
+-spec measure(fun(() -> term())) -> map().
+measure(F) -> measure(F, 300000).
+
+-spec measure(fun(() -> term()), timeout()) -> map().
+measure(F, Timeout) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+                    receive go -> ok end,
+                    %% The opening boundary. Its own event is dropped below.
+                    erlang:garbage_collect(),
+                    R = F(),
+                    %% The closing boundary, with `R' still referenced, so a
+                    %% result the caller keeps counts as live and not as
+                    %% reclaimed.
+                    erlang:garbage_collect(),
+                    Parent ! {done, self(), R}
+                end),
+    erlang:trace(Pid, true, [garbage_collection]),
+    Pid ! go,
+    Result = receive {done, Pid, R} -> R
+             after Timeout -> erlang:error(measure_timeout)
+             end,
+    %% Calling `trace_delivered/1' is not the barrier; waiting for its message
+    %% is. Draining with `after 0' drops events still in flight.
+    Ref = erlang:trace_delivered(Pid),
+    receive {trace_delivered, Pid, Ref} -> ok end,
+    %% No untrace: the process has already exited, and tracing a dead pid is a
+    %% badarg rather than a no-op.
+    Ends = [I || {trace, _, K, I} <- drain(),
+                 K =:= gc_minor_end orelse K =:= gc_major_end],
+    report(Ends, Result).
+
+report([], Result) ->
+    #{allocated => 0, reclaimed => 0, collections => 0, result => Result,
+      note => no_collections};
+report([Open | Rest], Result) ->
+    Live0 = live(Open),
+    Live1 = case Rest of [] -> Live0; _ -> live(lists:last(Rest)) end,
+    Reclaimed = lists:sum([w(I, wordsize) || I <- Rest]),
+    #{allocated => Reclaimed + Live1 - Live0,
+      reclaimed => Reclaimed,
+      live_before => Live0,
+      live_after => Live1,
+      collections => length(Rest),
+      %% Zero at both boundaries or the accounting has to explain them.
+      mbuf => {w(Open, mbuf_size), case Rest of
+                                       [] -> w(Open, mbuf_size);
+                                       _ -> w(lists:last(Rest), mbuf_size)
+                                   end},
+      result => Result}.
+
+live(I) -> w(I, heap_size) + w(I, old_heap_size).
+
+w(Info, Key) -> proplists:get_value(Key, Info, 0).
+
+drain() -> drain([]).
+
+drain(Acc) ->
+    receive {trace, _, _, _} = T -> drain([T | Acc])
+    after 0 -> lists:reverse(Acc)
+    end.
+
+%%% ---------------------------------------------------------------- proving ---
+
+-doc """
+Prove the estimator against a known allocation, in both of its forms.
+
+A list of N cons cells is 2N heap words. Retaining it through the closing
+collection exercises the live-set half of the formula; discarding it first
+exercises the reclaimed half. Both have to come out at about 2N once the fixed
+harness overhead is taken off, because the two halves are only sound together.
+""".
+-spec validate() -> ok | {error, term()}.
+validate() ->
+    #{allocated := Overhead} = measure(fun() -> ok end),
+    io:format("harness overhead ~w words~n~n", [Overhead]),
+    io:format("~10s ~14s ~14s ~10s ~10s~n",
+              ["N", "want", "retained", "discarded", "worst"]),
+    Rows = [row(N, Overhead) || N <- [100000, 1000000, 4000000]],
+    io:format("~n"),
+    case [R || {_, _, _, _, Err} = R <- Rows, Err > 0.05] of
+        [] -> io:format("estimator agrees within 5%~n"), ok;
+        Bad -> io:format("estimator is wrong: ~p~n", [Bad]), {error, Bad}
+    end.
+
+row(N, Overhead) ->
+    Want = 2 * N,
+    %% Returned, so it is still referenced at the closing collection.
+    #{allocated := Kept} = measure(fun() -> lists:duplicate(N, 0) end),
+    %% Built, summed and dropped, so the closing collection reclaims it.
+    #{allocated := Gone} = measure(fun() ->
+                                       L = lists:duplicate(N, 0),
+                                       lists:sum(L)
+                                   end),
+    K = Kept - Overhead,
+    G = Gone - Overhead,
+    Err = lists:max([abs(K - Want) / Want, abs(G - Want) / Want]),
+    io:format("~10w ~14w ~14w ~10w ~9.1f%~n", [N, Want, K, G, Err * 100]),
+    {N, Want, K, G, Err}.
+
+main(_) ->
+    case validate() of
+        ok -> init:stop();
+        {error, _} -> init:stop(1)
+    end.

--- a/bench/paths/guestarm.erl
+++ b/bench/paths/guestarm.erl
@@ -1,0 +1,104 @@
+-module(guestarm).
+-moduledoc """
+One start-up of a real language runtime, measured on the process that runs it.
+
+This is the arm the allocation work is judged by. It runs a guest that reads one
+JSON object from stdin and writes one back, which is a start-up plus one
+request, and reports what that cost the process doing it.
+
+    erlc -o bench/paths bench/paths/allocwords.erl bench/paths/guestarm.erl
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run guestarm main <guest.wasm> <script-dir> compile|load [workers]
+
+Everything it prints is per process, from that process's own collection trace,
+via `allocwords`. `erlang:statistics(garbage_collection)` is node-wide and gets
+this question wrong.
+
+Two things it always prints, because both have been read as results when they
+were not: whether the module went in **inline or as a handle**, so an arm that
+did not take its branch is visible, and the **reply**, so a guest that never
+reached its script cannot report a time.
+
+Worker positions are reported separately. The first wasm run in a fresh
+emulator costs about 2.4x the second on identical work, so a number without its
+position is not a number. One `erl` invocation is one emulator: to interleave,
+run this repeatedly rather than raising `workers`.
+""".
+
+-export([main/1]).
+
+%% Escaped quotes, so plain binaries rather than a `~"..."' sigil.
+-define(REQUEST, <<"{\"name\": \"ada\"}\n">>).
+-define(EXPECT, <<"{\"name\": \"ADA\"}">>).
+
+main([Guest, Dir, Mode]) -> main([Guest, Dir, Mode, "2"]);
+main([Guest, Dir, Mode, Workers]) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    {ok, Bin} = file:read_file(Guest),
+    io:format("~s | ~w bytes | sha256 ~s~n",
+              [filename:basename(Guest), byte_size(Bin),
+               binary:encode_hex(crypto:hash(sha256, Bin), lowercase)]),
+    io:format("load average ~s~n", [loadavg()]),
+    {ok, Mod} = case Mode of
+                    "load" -> wasm:load(Bin);
+                    "compile" -> wasm:compile(Bin)
+                end,
+    io:format("module went in ~s~n",
+              [case Mod of {wasm_module, _} -> "as a handle"; _ -> "inline" end]),
+    io:format("~n~-8s ~10s ~14s ~12s ~9s ~9s ~10s~n",
+              ["worker", "wall ms", "allocated", "reclaimed", "colls",
+               "live end", "reply"]),
+    [report(W, run(Mod, Dir)) || W <- lists:seq(1, list_to_integer(Workers))],
+    init:stop().
+
+report(W, #{wall := Wall, allocated := A, reclaimed := R, collections := C,
+            live_after := L, result := Reply}) ->
+    io:format("~-8w ~10w ~14w ~12w ~9w ~9w   ~s~n",
+              [W, Wall, A, R, C, L, ok_or(Reply)]).
+
+%% The reply, or what came instead. An arm that prints anything but `ok' here
+%% measured a guest that did not do the work.
+ok_or(?EXPECT) -> "ok";
+ok_or(Other) -> io_lib:format("WRONG ~p", [Other]).
+
+%% The whole guest runs inside the measured process: `allocwords' traces the
+%% process it spawns, so the instance has to live there too. The stdin fun
+%% answers once and then reports end of file, which is what lets `_start'
+%% return without a second process driving it.
+run(Mod, Dir) ->
+    T0 = erlang:monotonic_time(millisecond),
+    M = allocwords:measure(
+          fun() ->
+              Wasi = #{args => [~"python", ~"-u", ~"/app/worker.py"],
+                       dirs => [{~"/app", Dir, read}],
+                       stdin => fun(_) -> once(?REQUEST) end,
+                       stdout => fun(D) -> line(D) end,
+                       stderr => fun(_) -> ok end},
+              {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi),
+                                         #{max_memory_pages => 4096}),
+              _ = wasm:call(I, ~"_start", []),
+              ok = wasm:destroy(I),
+              get(line)
+          end),
+    M#{wall => erlang:monotonic_time(millisecond) - T0}.
+
+once(Data) ->
+    case get(sent) of
+        undefined -> put(sent, true), {ok, Data};
+        true -> eof
+    end.
+
+line(Data) ->
+    B = <<(case get(buf) of undefined -> <<>>; X -> X end)/binary,
+          (iolist_to_binary(Data))/binary>>,
+    case binary:split(B, ~"\n") of
+        [L, Rest] -> put(line, L), put(buf, Rest);
+        [_] -> put(buf, B)
+    end,
+    ok.
+
+loadavg() ->
+    case os:cmd("uptime") of
+        [] -> "unknown";
+        S -> string:trim(lists:last(string:split(S, "average", trailing)))
+    end.

--- a/bench/paths/guestarm.erl
+++ b/bench/paths/guestarm.erl
@@ -31,8 +31,10 @@ run this repeatedly rather than raising `workers`.
 -define(REQUEST, <<"{\"name\": \"ada\"}\n">>).
 -define(EXPECT, <<"{\"name\": \"ADA\"}">>).
 
-main([Guest, Dir, Mode]) -> main([Guest, Dir, Mode, "2"]);
-main([Guest, Dir, Mode, Workers]) ->
+main([Guest, Dir, Mode]) -> main([Guest, Dir, Mode, "2", "off"]);
+main([Guest, Dir, Mode, Workers]) -> main([Guest, Dir, Mode, Workers, "off"]);
+main([Guest, Dir, Mode, Workers, Tier]) ->
+    put(tier, Tier),
     {ok, _} = application:ensure_all_started(wasm),
     {ok, Bin} = file:read_file(Guest),
     io:format("~s | ~w bytes | sha256 ~s~n",
@@ -48,7 +50,9 @@ main([Guest, Dir, Mode, Workers]) ->
     io:format("~n~-8s ~10s ~14s ~12s ~9s ~9s ~10s~n",
               ["worker", "wall ms", "allocated", "reclaimed", "colls",
                "live end", "reply"]),
+    io:format("tier ~s~n", [get(tier)]),
     [report(W, run(Mod, Dir)) || W <- lists:seq(1, list_to_integer(Workers))],
+    io:format("~p~n", [wasm_jit:counts()]),
     init:stop().
 
 report(W, #{wall := Wall, allocated := A, reclaimed := R, collections := C,
@@ -75,12 +79,22 @@ run(Mod, Dir) ->
                        stdout => fun(D) -> line(D) end,
                        stderr => fun(_) -> ok end},
               {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi),
-                                         #{max_memory_pages => 4096}),
+                                         opts()),
               _ = wasm:call(I, ~"_start", []),
               ok = wasm:destroy(I),
               get(line)
           end),
     M#{wall => erlang:monotonic_time(millisecond) - T0}.
+
+%% `compile_after => 1' so the tier takes the module on its first hot call, and
+%% the executed set decides what it compiles: `compile_whole' on CPython's
+%% 11,448 functions is not a thing anybody would wait for.
+opts() ->
+    Base = #{max_memory_pages => 4096},
+    case get(tier) of
+        "on" -> Base#{compile => true, compile_after => 1};
+        _ -> Base
+    end.
 
 once(Data) ->
     case get(sent) of

--- a/bench/paths/perinstr.erl
+++ b/bench/paths/perinstr.erl
@@ -40,8 +40,10 @@
 %% interpreted and only these prices explain where its time goes.
 %% An optional second argument runs only the cases whose name contains it, so
 %% a probe into one instruction does not pay for `memory.copy 1024B' twice.
-main([Tier]) -> main([Tier, ""]);
-main([Tier, Only]) ->
+main([Tier]) -> main([Tier, "", "time"]);
+main([Tier, Only]) -> main([Tier, Only, "time"]);
+main([Tier, Only, What]) ->
+    put(what, What),
     {ok, _} = application:ensure_all_started(wasm),
     Opts = case Tier of
                "off" -> #{};
@@ -154,15 +156,20 @@ main([Tier, Only]) ->
          {"br_table 4 of 8 nested ",
           "(block $a (block $b (block $c (block $d (block $e (block $f (block $g (block $h (br_table $a $b $c $d $e $f $g $h (local.get $i))))))))))",
           9}],
-    io:format("~-24s ~10s ~10s~n", ["snippet", "ns/snip", "ns/instr"]),
+    io:format("~-24s ~10s ~10s~n",
+              ["snippet", unit(What, "/snip"), unit(What, "/instr")]),
     [run_case(Name, Snip, Instrs) || {Name, Snip, Instrs} <- Cases,
                                      string:find(Name, Only) =/= nomatch],
     init:stop().
 
+unit("alloc", Suffix) -> "words" ++ Suffix;
+unit(_, Suffix) -> "ns" ++ Suffix.
+
 run_case(Name, Snippet, Instrs) ->
     K = 20,
-    T1 = time_for(Snippet, K),
-    T2 = time_for(Snippet, 2 * K),
+    M = case get(what) of "alloc" -> fun alloc_for/2; _ -> fun time_for/2 end,
+    T1 = M(Snippet, K),
+    T2 = M(Snippet, 2 * K),
     Per = (T2 - T1) / K,
     io:format("~-24s ~10.2f ~10.2f~s~n", [Name, Per, Per / Instrs, note(Per)]).
 
@@ -187,6 +194,28 @@ time_for(Snippet, K) ->
                    || _ <- lists:seq(1, 5)]),
     ok = wasm:destroy(I),
     R * 1000 / N.
+
+%% Words this loop allocated, per iteration, from the process's own collection
+%% trace rather than a node-wide counter. Same K against 2K differential as the
+%% timing, so the loop and the harness cancel and what is left is the snippet.
+alloc_for(Snippet, K) ->
+    Src = source(Snippet, K),
+    {ok, P} = wasm_wat:module(Src),
+    {ok, M} = wasm_validate:module(P),
+    N = 200000,
+    Opts = get(opts),
+    #{allocated := A} =
+        allocwords:measure(
+          fun() ->
+              {ok, I} = wasm:instantiate(M, #{}, Opts),
+              %% One call first, so lowering and any compile are paid outside
+              %% the number: this is meant to price steady-state execution.
+              _ = wasm:call(I, ~"bench", [1]),
+              R = wasm:call(I, ~"bench", [N]),
+              ok = wasm:destroy(I),
+              R
+          end),
+    A / N.
 
 source(Snippet, K) ->
     Body = lists:duplicate(K, [Snippet, "\n        "]),

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -16,6 +16,12 @@ The arms:
   cold     one request, lowering inside the window. The baseline.
   pre      one request, every function lowered in the same process before the
            window opens, so the window holds no lowering at all.
+  whole    as `adopted`, with `compile_whole => true`, so the unit is every
+           eligible function rather than the ones the request ran. Its own
+           timeout, because 11,447 functions at `full` quality take far longer
+           than the ordinary arm ever does, and a timeout misread as a compiler
+           defect is exactly the sort of thing this file exists to prevent. Give
+           it a cache directory of its own and an empty one.
   adopted  a fresh instance that enters generated code on its *first* call.
            Reaching that today needs a priming instance to raise the ask,
            because `maybe_adopt/3` can only adopt what is already resident and
@@ -113,6 +119,9 @@ shape(pre, Bin, _Dir) ->
     {ok, Mod} = wasm:compile(Bin),
     {Mod, [?REQ1], fun(I) -> lower_all(I) end, false};
 
+shape(whole, Bin, Dir) ->
+    persistent_term:put({?MODULE, whole}, true),
+    shape(adopted, Bin, Dir);
 shape(adopted, Bin, Dir) ->
     %% On the heap like `compile/1`, and named like `load/1`. Without the
     %% identity `wasm_code_cache:key/6` refuses the module and nothing compiled
@@ -144,8 +153,15 @@ prime(Mod, Dir) ->
     I = inst(Mod, Dir, [?REQ1], true),
     {T, {R, _, _, _}} = call(I, false),
     io:format("priming call ~w ms, reply ~p~n", [T, R]),
-    io:format("waiting for the compiler~n"),
-    W = wait_compiled(3600, 0),
+    %% Four hours for the whole module, an hour otherwise. Both are ceilings
+    %% rather than expectations, and the wait reports as it goes so a long
+    %% compile is visibly a long compile and not a hang.
+    Ceiling = case persistent_term:get({?MODULE, whole}, false) of
+                  true -> 4 * 3600;
+                  false -> 3600
+              end,
+    io:format("waiting for the compiler, up to ~w s~n", [Ceiling]),
+    W = wait_compiled(Ceiling, 0),
     io:format("compiled after ~w s, ~p~n", [W, wasm_jit:counts()]).
 
 %% Long, and reported as it waits. Compiling CPython from cold took more than
@@ -178,8 +194,12 @@ inst(Mod, Dir, Reqs, Compile) ->
              stderr => fun(_) -> ok end},
     Limits = case Compile of
                  true ->
-                     Base = #{max_memory_pages => 4096, compile => true,
-                              compile_after => 1},
+                     Base0 = #{max_memory_pages => 4096, compile => true,
+                               compile_after => 1},
+                     Base = case persistent_term:get({?MODULE, whole}, false) of
+                                true -> Base0#{compile_whole => true};
+                                false -> Base0
+                            end,
                      case persistent_term:get({?MODULE, shards}, auto) of
                          auto -> Base;
                          N -> Base#{compile_shards => N}

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -1,0 +1,259 @@
+-module(pyarms).
+-moduledoc """
+The four CPython configurations, one emulator each, with what happened proved.
+
+A wall time on its own cannot say which of the four ran, so every arm prints
+the reply, `wasm_jit:counts/0`, the interpreted dispatch count and
+`code:which/1` for the modules that would be swapped by a `-pa` in the wrong
+order. An arm that did not do its work says so instead of reporting a number.
+
+    erlc -I _build/default/lib -o bench/paths bench/paths/pyarms.erl
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run pyarms main <guest.wasm> <script-dir> <arm> [cache-dir]
+
+The arms:
+
+  cold     one request, lowering inside the window. The baseline.
+  pre      one request, every function lowered in the same process before the
+           window opens, so the window holds no lowering at all.
+  adopted  a fresh instance that enters generated code on its *first* call.
+           Reaching that today needs a priming instance to raise the ask,
+           because `maybe_adopt/3` can only adopt what is already resident and
+           only the compiler puts anything there. The priming call is outside
+           the window and in its own process. The arm asserts `entered > 0`;
+           without that it is not this arm.
+  two      two requests to one instance. Subtracting `cold` gives the cost of a
+           request after Python has started, which is the number a prewarmed
+           pool would actually serve.
+""".
+
+-include_lib("wasm/include/wasm_exec.hrl").
+
+-export([main/1]).
+
+-define(REQ1, <<"{\"name\": \"ada\"}\n">>).
+-define(REQ2, <<"{\"name\": \"bob\"}\n">>).
+
+main([Guest, Dir, Arm]) -> main([Guest, Dir, Arm, "", "nocount"]);
+main([Guest, Dir, Arm, Cache]) -> main([Guest, Dir, Arm, Cache, "nocount"]);
+main([Guest, Dir, Arm, Cache, Count]) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    Cache =:= "" orelse application:set_env(wasm, code_cache_dir, Cache),
+    {ok, Bin} = file:read_file(Guest),
+    io:format("arm ~s~nguest ~s ~w bytes~n",
+              [Arm, hex(crypto:hash(sha256, Bin)), byte_size(Bin)]),
+    io:format("load average ~s~n", [loadavg()]),
+    [io:format("~-14w ~s~n", [M, code:which(M)])
+     || M <- [wasm_exec, wasm_instance, wasm_jit]],
+    run(list_to_atom(Arm), Bin, Dir, Count =:= "count"),
+    init:stop().
+
+%%% -------------------------------------------------------------------- arms ---
+
+%% One arm is not like the others: `inwin` puts instantiation *inside* the
+%% window, where every other arm has it in the setup. It exists because an
+%% earlier measurement of lowering differed from this one by 20 M words and the
+%% two harnesses disagreed about exactly this boundary.
+%% Lowering priced on its own, with nothing else in the window at all. This is
+%% the arm that settles what lowering costs, because it does not depend on
+%% subtracting one large number from another.
+run(loweronly, Bin, Dir, _Count) ->
+    {ok, Mod} = wasm:compile(Bin),
+    Res = allocwords:measure(
+            fun() -> inst(Mod, Dir, [?REQ1], false) end,
+            fun(I) ->
+                N = lower_all(I),
+                {0, {[{lowered, N}], not_counted, wasm_jit:counts()}}
+            end, 1800000),
+    show(Res);
+run(inwin, Bin, Dir, Count) ->
+    {ok, Mod} = wasm:compile(Bin),
+    wasm_jit:reset_counts(),
+    Res = allocwords:measure(
+            fun() -> ok end,
+            fun(_) -> call(inst(Mod, Dir, [?REQ1], false), Count) end, 1800000),
+    show(Res);
+run(Arm, Bin, Dir, Count) ->
+    {Mod, Reqs, Setup, Compile} = shape(Arm, Bin, Dir),
+    wasm_jit:reset_counts(),
+    Res = allocwords:measure(
+            fun() -> I = inst(Mod, Dir, Reqs, Compile), Setup(I), I end,
+            fun(I) -> call(I, Count) end, 1800000),
+    show(Res),
+    %% The traced wall is not the wall. A `load/1` arm emits about 35,000 GC
+    %% events and a compiled one a few hundred, so the instrument charges the
+    %% arms unequally; this repetition carries no tracing at all.
+    {T, R} = clean(Mod, Dir, Reqs, Setup, Compile),
+    io:format("clean wall        ~w ms, replies ~p~n", [T, R]),
+    io:format("jit after         ~p~n", [wasm_jit:counts()]).
+
+shape(cold, Bin, _Dir) ->
+    {ok, Mod} = wasm:compile(Bin),
+    {Mod, [?REQ1], fun(_) -> ok end, false};
+
+shape(two, Bin, _Dir) ->
+    {ok, Mod} = wasm:compile(Bin),
+    {Mod, [?REQ1, ?REQ2], fun(_) -> ok end, false};
+
+%% Lowering moved out of the window rather than removed from the run: the IR
+%% cache is keyed on the instance and lives in the process dictionary, so the
+%% only place this can happen is the measured process, before tracing starts.
+shape(pre, Bin, _Dir) ->
+    {ok, Mod} = wasm:compile(Bin),
+    {Mod, [?REQ1], fun(I) -> lower_all(I) end, false};
+
+shape(adopted, Bin, Dir) ->
+    %% On the heap like `compile/1`, and named like `load/1`. Without the
+    %% identity `wasm_code_cache:key/6` refuses the module and nothing compiled
+    %% is ever kept.
+    {ok, Mod} = wasm:compile(Bin,
+                             #{identity => {sha256, crypto:hash(sha256, Bin)}}),
+    prime(Mod, Dir),
+    {Mod, [?REQ1], fun(_) -> ok end, true}.
+
+clean(Mod, Dir, Reqs, Setup, Compile) ->
+    Parent = self(),
+    P = spawn(fun() ->
+                  I = inst(Mod, Dir, Reqs, Compile),
+                  Setup(I),
+                  {T, {Lines, _, _}} = call(I, false),
+                  Parent ! {clean, self(), T, Lines}
+              end),
+    receive {clean, P, T, L} -> {T, L} after 1800000 -> erlang:error(clean_timeout) end.
+
+%%% ----------------------------------------------------------------- priming ---
+
+%% One full interpreted call, in a process of its own, only to raise the ask
+%% that lets the compiler fill a slot -- from the disk cache when it is warm.
+%% Nothing here is measured.
+prime(Mod, Dir) ->
+    Parent = self(),
+    P = spawn(fun() ->
+                  I = inst(Mod, Dir, [?REQ1], true),
+                  {T, {L, _, _}} = call(I, false),
+                  Parent ! {primed, self(), T, L}
+              end),
+    receive {primed, P, T, R} ->
+        io:format("priming call ~w ms, reply ~p~n", [T, R])
+    after 1800000 -> erlang:error(prime_timeout)
+    end,
+    io:format("waiting for the compiler~n"),
+    W = wait_compiled(2400),
+    io:format("compiled after ~w s, ~p~n", [W, wasm_jit:counts()]).
+
+wait_compiled(0) -> erlang:error(never_compiled);
+wait_compiled(N) ->
+    case wasm_jit:counts() of
+        #{compiled := C} when C > 0 -> (2400 - N) div 4;
+        _ -> timer:sleep(250), wait_compiled(N - 1)
+    end.
+
+%%% ------------------------------------------------------------------ guests ---
+
+inst(Mod, Dir, Reqs, Compile) ->
+    put(reqs, Reqs),
+    Wasi = #{args => argv(Dir),
+             dirs => [{~"/app", Dir, read}],
+             stdin => fun(_) -> next() end,
+             stdout => fun(D) -> line(D) end,
+             stderr => fun(_) -> ok end},
+    Limits = case Compile of
+                 true -> #{max_memory_pages => 4096, compile => true,
+                           compile_after => 1};
+                 false -> #{max_memory_pages => 4096}
+             end,
+    {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi), Limits),
+    I.
+
+call(I, Count) ->
+    %% Dispatch counted rather than assumed: an arm that entered generated code
+    %% and one that did not are otherwise told apart only by a wall time.
+    %%
+    %% `ensure_loaded/1` first, and it is not decoration. `trace_pattern/3` on a
+    %% module the emulator has not loaded matches nothing and answers 0, and
+    %% `trace_info/2` then reads `undefined`, which prints as a missing count
+    %% rather than as a failure. Counting also charges the interpreting arm and
+    %% not the compiled one, so it is off unless asked for and never carries the
+    %% wall time.
+    Count andalso begin
+        {module, _} = code:ensure_loaded(wasm_exec),
+        1 = erlang:trace_pattern({wasm_exec, run, 3}, true, [call_count]),
+        ok
+    end,
+    T0 = erlang:monotonic_time(millisecond),
+    _ = wasm:call(I, ~"_start", []),
+    T = erlang:monotonic_time(millisecond) - T0,
+    N = case Count of
+            true ->
+                {call_count, C} = erlang:trace_info({wasm_exec, run, 3},
+                                                    call_count),
+                _ = erlang:trace_pattern({wasm_exec, run, 3}, false,
+                                         [call_count]),
+                C;
+            false -> not_counted
+        end,
+    Lines = lists:reverse(case get(lines) of undefined -> []; L -> L end),
+    ok = wasm:destroy(I),
+    {T, {Lines, N, wasm_jit:counts()}}.
+
+%% Every function, not the reached set: the window is what has to hold no
+%% lowering, and lowering more than the request needs only moves more of it out.
+lower_all(I) ->
+    T0 = erlang:monotonic_time(millisecond),
+    Fns = [F || F <- tuple_to_list(I#inst.funcs), is_record(F, fn)],
+    N = length([wasm_instance:body_of(F, I) || F <- Fns]),
+    io:format("pre-lowered ~w functions in ~w ms~n",
+              [N, erlang:monotonic_time(millisecond) - T0]),
+    N.
+
+%%% ------------------------------------------------------------------ output ---
+
+show(#{result := {T, {Lines, N, Counts}}} = R) ->
+    io:format("~nwall              ~w ms~n", [T]),
+    io:format("allocated         ~w words~n", [maps:get(allocated, R, 0)]),
+    io:format("reclaimed         ~w words~n", [maps:get(reclaimed, R, 0)]),
+    io:format("live before/after ~w / ~w words~n",
+              [maps:get(live_before, R, 0), maps:get(live_after, R, 0)]),
+    io:format("collections       ~w minor, ~w major~n",
+              [maps:get(minor, R, 0), maps:get(major, R, 0)]),
+    io:format("gc time           ~w ms (~.1f% of wall)~n",
+              [maps:get(gc_us, R, 0) div 1000,
+               case T of 0 -> 0.0; _ -> maps:get(gc_us, R, 0) / (T * 10) end]),
+    io:format("dispatches        ~w~n", [N]),
+    io:format("jit               ~p~n", [Counts]),
+    io:format("mbuf              ~p~n", [maps:get(mbuf, R, undefined)]),
+    io:format("replies           ~p~n", [Lines]).
+
+%%% ------------------------------------------------------------------ plumbing ---
+
+next() ->
+    case get(reqs) of
+        [] -> eof;
+        undefined -> eof;
+        [H | T] -> put(reqs, T), {ok, H}
+    end.
+
+line(Data) ->
+    B = <<(case get(buf) of undefined -> <<>>; X -> X end)/binary,
+          (iolist_to_binary(Data))/binary>>,
+    put(buf, take(B)),
+    ok.
+
+take(B) ->
+    case binary:split(B, ~"\n") of
+        [L, Rest] ->
+            put(lines, [L | case get(lines) of undefined -> []; X -> X end]),
+            take(Rest);
+        [_] -> B
+    end.
+
+argv(Dir) ->
+    case filelib:is_regular(filename:join(Dir, "worker.py")) of
+        true -> [~"python", ~"-u", ~"/app/worker.py"];
+        false -> [~"qjs", ~"/app/worker.js"]
+    end.
+
+hex(B) -> string:lowercase(binary:encode_hex(B)).
+
+loadavg() ->
+    string:trim(os:cmd("uptime | sed 's/.*averages*: //'")).

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -34,9 +34,12 @@ The arms:
 -define(REQ1, <<"{\"name\": \"ada\"}\n">>).
 -define(REQ2, <<"{\"name\": \"bob\"}\n">>).
 
-main([Guest, Dir, Arm]) -> main([Guest, Dir, Arm, "", "nocount"]);
-main([Guest, Dir, Arm, Cache]) -> main([Guest, Dir, Arm, Cache, "nocount"]);
+main([Guest, Dir, Arm]) -> main([Guest, Dir, Arm, "", "nocount", "1"]);
+main([Guest, Dir, Arm, Cache]) -> main([Guest, Dir, Arm, Cache, "nocount", "1"]);
 main([Guest, Dir, Arm, Cache, Count]) ->
+    main([Guest, Dir, Arm, Cache, Count, "1"]);
+main([Guest, Dir, Arm, Cache, Count, Shards]) ->
+    persistent_term:put({?MODULE, shards}, list_to_integer(Shards)),
     {ok, _} = application:ensure_all_started(wasm),
     Cache =:= "" orelse application:set_env(wasm, code_cache_dir, Cache),
     {ok, Bin} = file:read_file(Guest),
@@ -167,7 +170,9 @@ inst(Mod, Dir, Reqs, Compile) ->
              stderr => fun(_) -> ok end},
     Limits = case Compile of
                  true -> #{max_memory_pages => 4096, compile => true,
-                           compile_after => 1};
+                           compile_after => 1,
+                           compile_shards =>
+                               persistent_term:get({?MODULE, shards}, 1)};
                  false -> #{max_memory_pages => 4096}
              end,
     {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi), Limits),

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -34,12 +34,20 @@ The arms:
 -define(REQ1, <<"{\"name\": \"ada\"}\n">>).
 -define(REQ2, <<"{\"name\": \"bob\"}\n">>).
 
-main([Guest, Dir, Arm]) -> main([Guest, Dir, Arm, "", "nocount", "1"]);
-main([Guest, Dir, Arm, Cache]) -> main([Guest, Dir, Arm, Cache, "nocount", "1"]);
+main([Guest, Dir, Arm]) -> main([Guest, Dir, Arm, "", "nocount", "auto"]);
+main([Guest, Dir, Arm, Cache]) ->
+    main([Guest, Dir, Arm, Cache, "nocount", "auto"]);
 main([Guest, Dir, Arm, Cache, Count]) ->
-    main([Guest, Dir, Arm, Cache, Count, "1"]);
+    main([Guest, Dir, Arm, Cache, Count, "auto"]);
 main([Guest, Dir, Arm, Cache, Count, Shards]) ->
-    persistent_term:put({?MODULE, shards}, list_to_integer(Shards)),
+    %% `auto' leaves `compile_shards' out of the map entirely, which is the
+    %% configuration an acceptance run has to exercise: passing 1 would leave a
+    %% large guest refused and make a one-shard assertion vacuous.
+    persistent_term:put({?MODULE, shards},
+                        case Shards of
+                            "auto" -> auto;
+                            N -> list_to_integer(N)
+                        end),
     {ok, _} = application:ensure_all_started(wasm),
     Cache =:= "" orelse application:set_env(wasm, code_cache_dir, Cache),
     {ok, Bin} = file:read_file(Guest),
@@ -66,7 +74,7 @@ run(loweronly, Bin, Dir, _Count) ->
             fun() -> inst(Mod, Dir, [?REQ1], false) end,
             fun(I) ->
                 N = lower_all(I),
-                {0, {[{lowered, N}], not_counted, wasm_jit:counts()}}
+                {0, {[{lowered, N}], not_counted, wasm_jit:counts(), 0}}
             end, 1800000),
     show(Res);
 run(inwin, Bin, Dir, Count) ->
@@ -119,7 +127,7 @@ clean(Mod, Dir, Reqs, Setup, Compile) ->
     P = spawn(fun() ->
                   I = inst(Mod, Dir, Reqs, Compile),
                   Setup(I),
-                  {T, {Lines, _, _}} = call(I, false),
+                  {T, {Lines, _, _, _}} = call(I, false),
                   Parent ! {clean, self(), T, Lines}
               end),
     receive {clean, P, T, L} -> {T, L} after 1800000 -> erlang:error(clean_timeout) end.
@@ -134,7 +142,7 @@ clean(Mod, Dir, Reqs, Setup, Compile) ->
 %% reads exactly like an ask that went nowhere.
 prime(Mod, Dir) ->
     I = inst(Mod, Dir, [?REQ1], true),
-    {T, {R, _, _}} = call(I, false),
+    {T, {R, _, _, _}} = call(I, false),
     io:format("priming call ~w ms, reply ~p~n", [T, R]),
     io:format("waiting for the compiler~n"),
     W = wait_compiled(3600, 0),
@@ -169,10 +177,13 @@ inst(Mod, Dir, Reqs, Compile) ->
              stdout => fun(D) -> line(D) end,
              stderr => fun(_) -> ok end},
     Limits = case Compile of
-                 true -> #{max_memory_pages => 4096, compile => true,
-                           compile_after => 1,
-                           compile_shards =>
-                               persistent_term:get({?MODULE, shards}, 1)};
+                 true ->
+                     Base = #{max_memory_pages => 4096, compile => true,
+                              compile_after => 1},
+                     case persistent_term:get({?MODULE, shards}, auto) of
+                         auto -> Base;
+                         N -> Base#{compile_shards => N}
+                     end;
                  false -> #{max_memory_pages => 4096}
              end,
     {ok, I} = wasm:instantiate(Mod, wasi_preview1:imports(Wasi), Limits),
@@ -206,8 +217,11 @@ call(I, Count) ->
             false -> not_counted
         end,
     Lines = lists:reverse(case get(lines) of undefined -> []; L -> L end),
+    %% Before the destroy: the shard count is read from the resident chain, and
+    %% releasing the lease is what can take it away.
+    Shards = wasm_jit:shards(I),
     ok = wasm:destroy(I),
-    {T, {Lines, N, wasm_jit:counts()}}.
+    {T, {Lines, N, wasm_jit:counts(), Shards}}.
 
 %% Every function, not the reached set: the window is what has to hold no
 %% lowering, and lowering more than the request needs only moves more of it out.
@@ -221,7 +235,7 @@ lower_all(I) ->
 
 %%% ------------------------------------------------------------------ output ---
 
-show(#{result := {T, {Lines, N, Counts}}} = R) ->
+show(#{result := {T, {Lines, N, Counts, Shards}}} = R) ->
     io:format("~nwall              ~w ms~n", [T]),
     io:format("allocated         ~w words~n", [maps:get(allocated, R, 0)]),
     io:format("reclaimed         ~w words~n", [maps:get(reclaimed, R, 0)]),
@@ -234,6 +248,8 @@ show(#{result := {T, {Lines, N, Counts}}} = R) ->
                case T of 0 -> 0.0; _ -> maps:get(gc_us, R, 0) / (T * 10) end]),
     io:format("dispatches        ~w~n", [N]),
     io:format("jit               ~p~n", [Counts]),
+    io:format("shards resident   ~w~n", [Shards]),
+    io:format("diagnostics       ~p~n", [wasm_jit:diagnostics()]),
     io:format("mbuf              ~p~n", [maps:get(mbuf, R, undefined)]),
     io:format("replies           ~p~n", [Lines]).
 

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -138,14 +138,26 @@ prime(Mod, Dir) ->
     after 1800000 -> erlang:error(prime_timeout)
     end,
     io:format("waiting for the compiler~n"),
-    W = wait_compiled(2400),
+    W = wait_compiled(3600, 0),
     io:format("compiled after ~w s, ~p~n", [W, wasm_jit:counts()]).
 
-wait_compiled(0) -> erlang:error(never_compiled);
-wait_compiled(N) ->
+%% Long, and reported as it waits. Compiling CPython from cold took more than
+%% ten minutes on this box, and a deadline shorter than that reads as "the ask
+%% never reached the compiler" when the compiler is in fact running. The
+%% children count is what tells those two apart.
+wait_compiled(0, _) -> erlang:error(never_compiled);
+wait_compiled(N, Sec) ->
     case wasm_jit:counts() of
-        #{compiled := C} when C > 0 -> (2400 - N) div 4;
-        _ -> timer:sleep(250), wait_compiled(N - 1)
+        #{compiled := C} when C > 0 -> Sec;
+        _ ->
+            Sec rem 30 =:= 0 andalso
+                io:format("  ~w s ~p workers ~p~n",
+                          [Sec, wasm_jit:counts(),
+                           proplists:get_value(
+                             active,
+                             supervisor:count_children(wasm_jit_sup))]),
+            timer:sleep(1000),
+            wait_compiled(N - 1, Sec + 1)
     end.
 
 %%% ------------------------------------------------------------------ guests ---

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -126,13 +126,9 @@ clean(Mod, Dir, Reqs, Setup, Compile) ->
 %% One full interpreted call, only to raise the ask that lets the compiler fill
 %% a slot -- from the disk cache when it is warm. Nothing here is measured.
 %%
-%% In *this* process, and that is not a detail. Priming from a throwaway
-%% process compiles nothing at all: the worker starts, never receives its work
-%% and exits on `compiler_loop/0`'s 30-second timeout, with `compile/4` never
-%% entered and `release_ask/1` never called. Keeping the same spawned process
-%% alive instead, the compiler is still running at 105 seconds. So the ask does
-%% not survive the process that raised it, which is the shape every one-shot
-%% `wasm32-wasi` worker has.
+%% In this process rather than a spawned one, which costs nothing and removes a
+%% variable: compiling QuickJS takes 165 seconds, so a wait that is too short
+%% reads exactly like an ask that went nowhere.
 prime(Mod, Dir) ->
     I = inst(Mod, Dir, [?REQ1], true),
     {T, {R, _, _}} = call(I, false),

--- a/bench/paths/pyarms.erl
+++ b/bench/paths/pyarms.erl
@@ -123,20 +123,20 @@ clean(Mod, Dir, Reqs, Setup, Compile) ->
 
 %%% ----------------------------------------------------------------- priming ---
 
-%% One full interpreted call, in a process of its own, only to raise the ask
-%% that lets the compiler fill a slot -- from the disk cache when it is warm.
-%% Nothing here is measured.
+%% One full interpreted call, only to raise the ask that lets the compiler fill
+%% a slot -- from the disk cache when it is warm. Nothing here is measured.
+%%
+%% In *this* process, and that is not a detail. Priming from a throwaway
+%% process compiles nothing at all: the worker starts, never receives its work
+%% and exits on `compiler_loop/0`'s 30-second timeout, with `compile/4` never
+%% entered and `release_ask/1` never called. Keeping the same spawned process
+%% alive instead, the compiler is still running at 105 seconds. So the ask does
+%% not survive the process that raised it, which is the shape every one-shot
+%% `wasm32-wasi` worker has.
 prime(Mod, Dir) ->
-    Parent = self(),
-    P = spawn(fun() ->
-                  I = inst(Mod, Dir, [?REQ1], true),
-                  {T, {L, _, _}} = call(I, false),
-                  Parent ! {primed, self(), T, L}
-              end),
-    receive {primed, P, T, R} ->
-        io:format("priming call ~w ms, reply ~p~n", [T, R])
-    after 1800000 -> erlang:error(prime_timeout)
-    end,
+    I = inst(Mod, Dir, [?REQ1], true),
+    {T, {R, _, _}} = call(I, false),
+    io:format("priming call ~w ms, reply ~p~n", [T, R]),
     io:format("waiting for the compiler~n"),
     W = wait_compiled(3600, 0),
     io:format("compiled after ~w s, ~p~n", [W, wasm_jit:counts()]).

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -84,6 +84,27 @@ That is one shot: a function that first runs after the module was built stays
 interpreted. So this suits long-lived instances of modules you run repeatedly,
 and a workload whose hot set changes over time gets less from it.
 
+**A large hot set is compiled into several BEAM modules, not one.** Every name a
+unit can use comes from a pool generated at startup, because nothing a guest
+supplies may become an atom, and that pool is 2048 functions deep. A hot set
+past it is split across as many as four units, automatically; below it nothing
+is split, because a call between units is a crossing rather than a call. Ask
+`wasm_jit:shard_count(NFuns, Limits)` what a given hot set would do, or
+`wasm_jit:shards(Instance)` how many units it is actually resident in.
+
+CPython 3.12 reaches 2,333 functions in a single `_start`, so it splits in two.
+Before that split happened it was refused outright, and silently:
+
+    1> wasm_jit:counts().
+    #{compiled => 0, entered => 0, reentered => 0, cached => 0,
+      refused => 1, failed => 0, crashed => 0}
+    2> wasm_jit:diagnostics().
+    [{refused, {{sha256, <<...>>}, 3}, {limit, {too_many_functions, 8196}}}]
+
+Past four units there is no split that fits and the answer is that refusal.
+`counts/0` says how many, `diagnostics/0` says what: the reasons are normalised
+to a bounded shape and the last few dozen are kept.
+
 ## What turns it off underneath you
 
 **Every refusal means interpret**, and none of them is an error: a function
@@ -217,13 +238,14 @@ An unrecognised profile is `{error, #{kind := unknown_profile}}`, not a crash.
 
 ## Short notes
 
-- `baseline` is the default: it skips the OTP compiler's SSA optimiser, which
-  costs **123.1 seconds against 54.8** on QuickJS's hot set and buys nothing
-  measurable. The warm run is 141.1 ms against 142.1, and a tight arithmetic
-  loop is 3.35 ns an iteration either way over five interleaved pairs. Ask for
-  `#{compile_quality => full}` if you find a workload where it pays; the 86%
-  penalty this default once existed to avoid is no longer reproducible.
-  Figures in `test/audit/PERF.md`.
+- `full` is the default, which the profile table above says and this note used
+  to contradict. `baseline` skips the OTP compiler's SSA optimiser and was the
+  default while that optimiser bought nothing measurable; it buys something now,
+  because the generator states value ranges the pass can use. QuickJS is **75.0
+  to 76.8 ms at `full` against 86.1 to 87.7 at `baseline`**, and `full` costs
+  129.3 seconds against 58.1 to compile the hot set. Ask for
+  `#{compile_quality => baseline}` when the compile time matters more than the
+  run. Figures in `test/audit/PERF.md`.
 - Turning the tier on by default is a decision that has not been made. Every
   gate passes; the recommendation is still no, because it is 8.4x on one real
   workload and flat on another.

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -192,7 +192,7 @@ generated code having run.
 | option | what it changes |
 | --- | --- |
 | `compile_sync` | compile on the calling process, so the next call is already compiled |
-| `compile_whole` | compile every eligible function, not only the ones that have run |
+| `compile_whole` | compile every eligible function, not only the ones that have run. Honoured on the background path as well as under `compile_sync`; it silently was not, and compiled what had run instead |
 | `compile_force` | raise on a compile error instead of interpreting |
 
 `wasm_spec_SUITE:compiled_phase` sets all three and then asserts

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -84,24 +84,31 @@ That is one shot: a function that first runs after the module was built stays
 interpreted. So this suits long-lived instances of modules you run repeatedly,
 and a workload whose hot set changes over time gets less from it.
 
-**A large hot set is compiled into several BEAM modules, not one.** Every name a
-unit can use comes from a pool generated at startup, because nothing a guest
-supplies may become an atom, and that pool is 2048 functions deep. A hot set
-past it is split across as many as four units, automatically; below it nothing
-is split, because a call between units is a crossing rather than a call. Ask
-`wasm_jit:shard_count(NFuns, Limits)` what a given hot set would do, or
+**A very large hot set is compiled into several BEAM modules, not one.** Every
+name a unit can use comes from a pool generated at startup, because nothing a
+guest supplies may become an atom, and that pool is **4096** functions deep. A
+hot set past it is split across as many as four units, automatically; below it
+nothing is split, and you want it not to be, for two reasons. A call between
+units is a crossing rather than a call, which costs: CPython allocates 217 M
+words in one unit against 306 M in four. And **only a unit that ends its chain
+is cached on disk**, so a split hot set is recompiled on every node.
+
+Ask `wasm_jit:shard_count(NFuns, Limits)` what a given hot set would do, or
 `wasm_jit:shards(Instance)` how many units it is actually resident in.
 
-CPython 3.12 reaches 2,333 functions in a single `_start`, so it splits in two.
-Before that split happened it was refused outright, and silently:
+CPython 3.12 reaches 2,333 functions in a single `_start`, which is one unit and
+an 80 MB artifact: 1,105 seconds to compile the first time, two seconds on the
+next node to see it.
+
+Past four units there is no split that fits, and the answer is a refusal rather
+than silence:
 
     1> wasm_jit:counts().
     #{compiled => 0, entered => 0, reentered => 0, cached => 0,
       refused => 1, failed => 0, crashed => 0}
     2> wasm_jit:diagnostics().
-    [{refused, {{sha256, <<...>>}, 3}, {limit, {too_many_functions, 8196}}}]
+    [{refused, {{sha256, <<...>>}, 3}, {limit, {too_many_functions, 16385}}}]
 
-Past four units there is no split that fits and the answer is that refusal.
 `counts/0` says how many, `diagnostics/0` says what: the reasons are normalised
 to a bounded shape and the last few dozen are kept.
 
@@ -203,6 +210,12 @@ specification says -1.
 `compile_whole` is not a tuning knob. Compiling every function of QuickJS is 74
 seconds against about 8 for the hot set. Specification modules are a few
 functions each, which is why it is affordable there and nowhere else.
+
+**Nowhere else is meant literally.** Pointed at CPython 3.12, whose 11,447
+eligible functions are inside the four-unit ceiling and so are not refused, it
+reached 33 GB resident on a 48 GB machine in eleven minutes, published nothing,
+and spent that time paging rather than compiling. The ceiling bounds the names a
+unit can use; it is not a promise that everything under it will compile.
 
 ## Pick a profile instead of the knobs
 

--- a/src/wasm_code_slots.erl
+++ b/src/wasm_code_slots.erl
@@ -105,6 +105,7 @@ reasoning.
 -export([resident_module/1]).
 -export([lease_call/1, lease_call/2, release_call/1, calls_in/1]).
 -export([hot/2]).
+-export([record_diagnostic/4, diagnostics/0, clear_diagnostics/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -export_type([key/0, lease/0, token/0]).
@@ -137,6 +138,12 @@ reasoning.
 %% `?TAB' walks the whole thing, and a counter row would have to be skipped by
 %% each of them.
 -define(CALLS, wasm_code_calls).
+
+%% Why the compiles that did not happen did not happen, newest last, bounded.
+%% An `ordered_set' keyed by a sequence the caller supplies, so two compilers
+%% recording at once are two independent inserts and never a read-modify-write.
+-define(DIAG, wasm_code_diag).
+-define(DIAG_ROWS, 64).
 
 %% One counter per slot, holding the number of calls currently inside its code,
 %% plus `?EXCL' while the manager is replacing it. Published in `persistent_term'
@@ -201,7 +208,66 @@ ensure_table() ->
             ok;
         _ -> ok
     end,
+    case ets:info(?DIAG, name) of
+        undefined ->
+            ?DIAG = ets:new(?DIAG, [named_table, public, ordered_set,
+                                    {write_concurrency, true}]),
+            ok;
+        _ -> ok
+    end,
     ensure_counters().
+
+-doc """
+Record why one compile did not happen.
+
+`Seq` comes from the caller, which holds a node-wide `atomics` counter, so this
+is one insert and never a read-modify-write: two compilers recording at the same
+moment cannot lose each other's row.
+
+`Reason` must already be normalised. Nothing here bounds it, and the OTP
+compiler's diagnostics and an exit reason's stacktrace are both unbounded.
+
+A no-op when the table is not there, which is what a node that loaded these
+modules without restarting the application has. Reporting a failure must never
+be a failure.
+""".
+-spec record_diagnostic(pos_integer(), atom(), term(), term()) -> ok.
+record_diagnostic(Seq, Outcome, Key, Reason) ->
+    case ets:whereis(?DIAG) of
+        undefined -> ok;
+        _ ->
+            true = ets:insert(?DIAG, {Seq, Outcome, Key, Reason,
+                                      erlang:system_time(second)}),
+            trim()
+    end.
+
+%% Oldest first out, and deleting a key another process has already taken is a
+%% no-op, so two trims at once cost a wasted lookup and nothing else.
+trim() ->
+    case ets:info(?DIAG, size) > ?DIAG_ROWS of
+        false -> ok;
+        true ->
+            case ets:first(?DIAG) of
+                '$end_of_table' -> ok;
+                K -> true = ets:delete(?DIAG, K), trim()
+            end
+    end.
+
+-doc "Every recorded diagnostic, oldest first. `[]` when the table is absent.".
+-spec diagnostics() -> [{atom(), term(), term()}].
+diagnostics() ->
+    case ets:whereis(?DIAG) of
+        undefined -> [];
+        _ -> [{O, K, R} || {_Seq, O, K, R, _At} <- ets:tab2list(?DIAG)]
+    end.
+
+-doc "Forget them. The caller's sequence is deliberately not reset with them.".
+-spec clear_diagnostics() -> ok.
+clear_diagnostics() ->
+    case ets:whereis(?DIAG) of
+        undefined -> ok;
+        _ -> true = ets:delete_all_objects(?DIAG), ok
+    end.
 
 %% Separate from the table's own guard: the counters are a different resource
 %% and a table that already exists says nothing about whether they do.

--- a/src/wasm_core.erl
+++ b/src/wasm_core.erl
@@ -526,7 +526,15 @@ forms(Name, Unit, Sigs, TSigs, Stamp, Next, Head, Elsewhere) ->
         Exports = [cerl:c_fname(invoke, 6)],
         {ok, cerl:c_module(cerl:c_atom(Name), Exports, [], [Invoke | Defs])}
     catch
-        throw:{limit, _} = L -> {error, L};
+        %% `error:`, not `throw:`. `fun_name/1` and `frame_name/1` raise with
+        %% `erlang:error/1`, and this clause spelled `throw:` for long enough
+        %% that a module past `?MAX_FUNS` -- CPython reaches 2,333 functions
+        %% against a bound of 2,048 -- escaped as an exception instead of
+        %% arriving as a value. `wasm_jit:compiler_loop/0` swallowed it, so the
+        %% tier refused the guest silently and for ever. The helpers keep their
+        %% contract, which `wasm_core_SUITE` asserts with `?assertError`; the
+        %% boundary is what was wrong.
+        error:{limit, _} = L -> {error, L};
         throw:{unsupported, _} = U -> {error, U}
     end.
 

--- a/src/wasm_core.erl
+++ b/src/wasm_core.erl
@@ -52,7 +52,13 @@ every other refusal here: interpret it.
 
 %% Read these as the answer to "how many atoms can this module make", which is
 %% `?MAX_FUNS + ?MAX_FRAMES` and nothing else, ever.
--define(MAX_FUNS, 2048).      % qjs has 1666 compilable functions
+%% 4096, sized against CPython rather than QuickJS. QuickJS is 1666 compilable
+%% functions and fitted 2048 comfortably; CPython 3.12 reaches 2,333 in one
+%% `_start' and 11,447 in the whole module, and the first of those is the number
+%% that matters. A hot set inside one unit is a hot set `wasm_jit:artifact/8'
+%% can put in the on-disk cache, because only a unit that ends the chain is
+%% cacheable; split in two it is recompiled on every node for ever.
+-define(MAX_FUNS, 4096).
 -define(MAX_FRAMES, 512).     % qjs nests 257 deep at worst
 -define(MAX_ARITY, 128).      % qjs would generate 71 at worst; the BEAM allows 255
 
@@ -528,8 +534,8 @@ forms(Name, Unit, Sigs, TSigs, Stamp, Next, Head, Elsewhere) ->
     catch
         %% `error:`, not `throw:`. `fun_name/1` and `frame_name/1` raise with
         %% `erlang:error/1`, and this clause spelled `throw:` for long enough
-        %% that a module past `?MAX_FUNS` -- CPython reaches 2,333 functions
-        %% against a bound of 2,048 -- escaped as an exception instead of
+        %% that a module past `?MAX_FUNS` -- CPython reaches 2,333 functions,
+        %% against a then-bound of 2,048 -- escaped as an exception instead of
         %% arriving as a value. `wasm_jit:compiler_loop/0` swallowed it, so the
         %% tier refused the guest silently and for ever. The helpers keep their
         %% contract, which `wasm_core_SUITE` asserts with `?assertError`; the

--- a/src/wasm_core.erl
+++ b/src/wasm_core.erl
@@ -1063,10 +1063,14 @@ instr({call, F}, Rest, #g{unit = Unit, sigs = Sigs} = G0, Exit) ->
                            seq(Rest, G3#g{mut = M1,
                                           stack = lists:reverse(Rs) ++ G1#g.stack},
                                Exit)),
-    %% The depth check is the caller's, so a runaway recursion raises what
+    %% The depth check is this frame's own, so a runaway recursion raises what
     %% `enter/5' raises instead of growing the Erlang stack until the process
     %% runs out of heap.
-    cerl:c_seq(call_op(check_depth, [G0#g.inst, G0#g.d]),
+    %%
+    %% `G0#g.d' is the *caller's* depth -- `invoke_fn/4' takes it that way -- so
+    %% this function's own is `deeper(G0)', and checking `G0#g.d' allowed one
+    %% frame more than the interpreter: 1000 against 999 at `max_depth => 1000'.
+    cerl:c_seq(call_op(check_depth, [G0#g.inst, deeper(G0)]),
                cerl:c_case(Call, [Clause]));
 
 instr({call_indirect, TypeIdx, TableIdx}, Rest,
@@ -1091,7 +1095,7 @@ instr({call_indirect, TypeIdx, TableIdx}, Rest,
                            seq(Rest, G4#g{mut = M1,
                                           stack = lists:reverse(Rs) ++ G2#g.stack},
                                Exit)),
-    cerl:c_seq(call_op(check_depth, [G0#g.inst, G0#g.d]),
+    cerl:c_seq(call_op(check_depth, [G0#g.inst, deeper(G0)]),
                cerl:c_case(Call, [Clause]));
 
 %%% ---------------------------------------------------------------- numeric ---

--- a/src/wasm_exec.erl
+++ b/src/wasm_exec.erl
@@ -113,7 +113,7 @@ init_state(Inst, Mut, _Args, Opts) ->
     {Fuel, Depth, MaxDepth} =
         case get(?BUDGET) of
             undefined ->
-                {maps:get(fuel, Opts, infinity), 0,
+                {maps:get(fuel, Opts, infinity), maps:get(depth, Opts, 0),
                  maps:get(max_depth, Opts, 1024)};
             {F, _HC, D, _Max, MD} ->
                 {F, D, MD}
@@ -999,10 +999,44 @@ call_out(Inst, Mut, Idx, Args, Depth, Mod, Gen) ->
     %% The name and the generation come from the caller as literals, because the
     %% caller *is* the generated module and knew both when it was built. Reading
     %% them out of the slot table instead would put a lookup on every crossing.
-    Limits = (Inst#inst.limits)#{max_depth => max_depth(Inst) - Depth,
-                                 code_module => {Mod, Gen}},
-    {ok, Results, Mut1} = call(Inst, Mut, Idx, Args, Limits),
+    Limits = (Inst#inst.limits)#{code_module => {Mod, Gen}},
+    {ok, Results, Mut1} =
+        with_depth(Depth, fun(Extra) ->
+                              call(Inst, Mut, Idx, Args, maps:merge(Limits, Extra))
+                          end),
     {Results, Mut1}.
+
+-doc """
+Run a nested invocation at an absolute depth, and give the caller's back after.
+
+Every boundary that starts one has to do this, or `max_depth` counts a fresh
+recursion each time round. `call_out/7` reduced the *ceiling* instead and
+`init_state/4` discarded it -- with a budget present, which there always is under
+`wasm:call/4`, the depth and the ceiling both come from the budget -- so a guest
+alternating tiers reached 99,999 frames against a limit of 1000.
+
+Only the depth is restored. The nested run raises fuel through `publish_fuel/1`
+and the host-call count through `charge_host_call/1`, and putting the whole tuple
+back would let a compiled function reset `max_host_calls` by crossing out and
+returning. `after`, so a trap unwinding through the crossing restores it too.
+""".
+-spec with_depth(non_neg_integer(), fun((map()) -> term())) -> term().
+with_depth(Depth, Fun) ->
+    case get(?BUDGET) of
+        %% No budget to thread through: the base travels in the options, which
+        %% `init_state/4' reads when it finds none.
+        undefined ->
+            Fun(#{depth => Depth});
+        Prev ->
+            put(?BUDGET, setelement(3, Prev, Depth)),
+            try Fun(#{})
+            after
+                case get(?BUDGET) of
+                    undefined -> ok;
+                    Now -> put(?BUDGET, setelement(3, Now, element(3, Prev)))
+                end
+            end
+    end.
 
 -doc """
 Call a function this generated module does not hold but a sibling does.
@@ -1075,7 +1109,16 @@ indirect_out(Inst, Mut, TypeIdx, TableIdx, I, Args, Depth, Mod, Gen) ->
         %% written back, and this instance's is untouched.
         {foreign, FInst, F} ->
             FMut = wasm_instance:mut(FInst),
-            {ok, Results, FMut1} = call(FInst, FMut, F, Args, FInst#inst.limits),
+            %% Through `with_depth/2` like every other nested invocation: this
+            %% branch ignored its `Depth` entirely, so two instances calling
+            %% each other through a shared table evaded `max_depth` the same way
+            %% a mixed tier did.
+            {ok, Results, FMut1} =
+                with_depth(Depth,
+                           fun(Extra) ->
+                               call(FInst, FMut, F, Args,
+                                    maps:merge(FInst#inst.limits, Extra))
+                           end),
             ok = wasm_instance:set_mut(FInst, FMut1),
             {Results, Mut}
     end.
@@ -1467,6 +1510,15 @@ do_call(F, Cont, Ctrl, #st{code = {Mod, Gen}, inst = Inst, mut = Mu} = St) ->
             %% walk of the operand stack.
             {Locals, Stack1} = pop_locals(NP, St#st.stack, Fn#fn.defaults),
             St1 = St#st{stack = Stack1},
+            %% The same check `enter/5' makes before it creates an interpreted
+            %% frame. Generated code checks before its own calls, not on entry,
+            %% so without this an interpreted caller could put a compiled frame
+            %% one past `max_depth' and a callee that returned without calling
+            %% would never notice: the mixed tier bounded at 9 where both pure
+            %% ones bounded at 8.
+            St#st.depth >= St#st.max_depth andalso
+                wasm_error:exhaustion(call_stack_exhausted,
+                                      #{depth => St#st.depth}),
             try Mod:invoke(Inst, Mu, F, lists:sublist(Locals, NP), St#st.depth,
                            Gen) of
                 %% Most functions of a real module are outside the subset. Not a
@@ -1735,7 +1787,16 @@ foreign_call(FInst, F, Cont, Ctrl, St) ->
     %% An exception that escapes the callee is not the callee's failure: it
     %% keeps unwinding in *this* instance, where a `try_table' may catch it.
     %% Only reaching the outermost invocation makes it an error.
-    try wasm_exec:call(FInst, FMut, F, Args, Limits) of
+    %%
+    %% `with_depth/2` for the same reason as every other nested invocation. Fuel
+    %% is *not* settled here and that is a known gap: a callee that spends fuel
+    %% and then throws loses its final value, because only `leave/2` publishes
+    %% and `uncaught/1` throws and nothing else. See `test/audit/PERF.md`.
+    try with_depth(St#st.depth,
+                   fun(Extra) ->
+                       wasm_exec:call(FInst, FMut, F, Args,
+                                      maps:merge(Limits, Extra))
+                   end) of
         {ok, Results, FMut1} ->
             ok = wasm_instance:set_mut(FInst, FMut1),
             run(Cont, Ctrl, St#st{stack = lists:reverse(Results) ++ Stack1})

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -55,6 +55,7 @@ moved, because even with all three a refusal still interprets.
 
 -export([entry/3, after_call/2, counts/0, reset_counts/0, await/2, release/1]).
 -export([diagnostics/0, normalize_reason/1, shard_count/2, shards/1]).
+-export([compile_limits/0]).
 -export([reentered/0]).
 -export([compiler_loop/0]).
 -export([dump/1, dump/2]).
@@ -76,6 +77,21 @@ moved, because even with all three a refusal still interprets.
 %% whole node shares, and a call between units is a crossing rather than a call
 %% -- so it happens only when one unit will not fit. See `shard_count/2`.
 -define(MAX_SHARDS, 4).
+
+%% How much work the runtime will accept in one request, which is a different
+%% question from how many names a unit may draw. It was `?MAX_SHARDS *
+%% max_funs`, so raising the name pool from 2048 to 4096 raised this from 8,192
+%% to 16,384 and admitted a CPython whole-module compile measured at 33 GB
+%% resident on a 48 GB box, paging and publishing nothing. A separate constant
+%% because the two answer different questions and moving one should not move the
+%% other.
+%%
+%% Counted over the *requested* set, before anything is lowered. Words would
+%% predict the cost better -- 11 to 17 KB of allocated peak per IR word on both
+%% guests -- but any value is loose or wrong until the selector makes requests
+%% small: CPython's accepted hot set is 3.7 M words and peaked at 59.89 GB, so a
+%% ceiling admitting today's ordinary path would protect nothing.
+-define(MAX_COMPILE_FUNS, 8192).
 %% Set by `entry_1/3` when this call found the module hot and unbuilt, read by
 %% `after_call/2` once the call has finished. The invocation's own lifetime is
 %% exactly the right one for it, which is the same argument the checkpoint key
@@ -634,13 +650,34 @@ compile(Inst, Limits, Executed, Mode) ->
     end.
 
 generate(Inst, Limits, Mod, Token, Executed) ->
-    case unit(Inst, Executed) of
-        [] ->
+    %% Counted here, over what was *asked for*, because `unit/2` lowers every
+    %% selected function through `wasm_instance:compiler_ir/2` before
+    %% `can_compile/2` filters it. A refused request would otherwise have built
+    %% and retained its whole IR first, and a module of many unsupported
+    %% functions could lower an arbitrary number of them while never reaching
+    %% the ceiling in *eligible* ones. `unit/2` keeps answering a list, because
+    %% `dump/2` uses it as a list comprehension's generator.
+    N = requested(Inst, Executed),
+    case N > ?MAX_COMPILE_FUNS of
+        true ->
             ok = wasm_code_slots:abort(Token),
-            retry;
-        Unit ->
-            generate_1(Inst, Limits, Mod, Token, Unit)
+            {refused, {limit, {too_many_functions, N}}};
+        false ->
+            case unit(Inst, Executed) of
+                [] ->
+                    ok = wasm_code_slots:abort(Token),
+                    retry;
+                Unit ->
+                    generate_1(Inst, Limits, Mod, Token, Unit)
+            end
     end.
+
+%% `[]` is `wanted/2`'s way of saying every function, so the count is the
+%% module's own.
+requested(Inst, []) ->
+    length([F || F <- tuple_to_list(Inst#inst.funcs), is_record(F, fn)]);
+requested(_Inst, Executed) ->
+    length(Executed).
 
 %% Refused before anything is generated when even `?MAX_SHARDS` units cannot
 %% hold it. `length/1` on the eligible list is the whole cost of finding out,
@@ -648,7 +685,7 @@ generate(Inst, Limits, Mod, Token, Executed) ->
 %% Core Erlang for every function up to the pool's depth has been built.
 generate_1(Inst, Limits, Mod, Token, Unit) ->
     N = length(Unit),
-    case N > ?MAX_SHARDS * map_get(max_funs, wasm_core:limits()) of
+    case N > ?MAX_COMPILE_FUNS of
         true ->
             ok = wasm_code_slots:abort(Token),
             {refused, {limit, {too_many_functions, N}}};
@@ -787,6 +824,15 @@ split(Unit, Limits) ->
                 Parts -> renumber(Parts)
             end
     end.
+
+-doc """
+Every bound the compiled tier applies to a *request*, so a caller can ask rather
+than infer it from a refusal. `wasm_core:limits/0` is the same idea for the
+bounds a single unit has.
+""".
+-spec compile_limits() -> #{atom() => pos_integer()}.
+compile_limits() ->
+    #{max_compile_funs => ?MAX_COMPILE_FUNS, max_shards => ?MAX_SHARDS}.
 
 -doc """
 How many units this many functions are split into.

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -65,7 +65,12 @@ moved, because even with all three a refusal still interprets.
 
 %% Bumped whenever the shape of generated code changes, so that code compiled by
 %% an older version of this runtime is never entered by a newer one.
--define(ABI, 3).
+%%
+%% 4: `check_depth/2` is passed the calling frame's own depth rather than its
+%% caller's. An artifact built by 3 checks one level too shallow, which is
+%% exactly the divergence `every_tier_bounds_recursion_at_the_same_depth`
+%% exists to catch -- and a cached one would reintroduce it silently.
+-define(ABI, 4).
 
 -define(DEFAULT_AFTER, 32).
 

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -636,7 +636,7 @@ generate(Inst, Limits, Mod, Token, Executed) ->
 %% Refused before anything is generated when even `?MAX_SHARDS` units cannot
 %% hold it. `length/1` on the eligible list is the whole cost of finding out,
 %% and the alternative is discovering it inside `wasm_core:fun_name/1` after the
-%% Core Erlang for every function before the 2049th has been built.
+%% Core Erlang for every function up to the pool's depth has been built.
 generate_1(Inst, Limits, Mod, Token, Unit) ->
     N = length(Unit),
     case N > ?MAX_SHARDS * map_get(max_funs, wasm_core:limits()) of

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -112,7 +112,16 @@ does not use this pays one map lookup.
 -spec entry(#inst{}, map(), fun()) -> fun().
 entry(Inst, Limits, Entry) ->
     case maps:get(compile, Limits, false) andalso
-         maps:get(fuel, Limits, infinity) =:= infinity of
+         maps:get(fuel, Limits, infinity) =:= infinity andalso
+         %% A per-call `max_depth' does not reach generated code, which reads
+         %% its ceiling from the instance, so an invocation that overrides it
+         %% interprets rather than silently getting the instance's. `wasm.erl'
+         %% merges the call's options over the instance's before calling this,
+         %% so an override shows as a difference between the two maps. The
+         %% alternative -- reading the budget inside `check_depth/2' -- puts a
+         %% process dictionary lookup on the compiled call path.
+         maps:get(max_depth, Limits, undefined) =:=
+             maps:get(max_depth, Inst#inst.limits, undefined) of
         false -> Entry;
         true -> entry_1(Inst, Limits, Entry)
     end.

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -512,15 +512,20 @@ wanted(Limits, Inst) ->
     end.
 
 spawn_compile(Inst, Limits) ->
-    %% Read here rather than in the compiler, because the record of what has
-    %% run lives in *this* process's dictionary and the compiler's is empty.
-    Executed = wasm_instance:executed(Inst),
+    %% Read here rather than in the compiler, because the record of what has run
+    %% lives in *this* process's dictionary and the compiler's is empty.
+    %%
+    %% Through `wanted/2`, which is also where `compile_whole` is honoured.
+    %% Reading `wasm_instance:executed/1` directly, as this did, made that
+    %% option work only under `compile_sync`: everything asked for in the
+    %% background compiled what had run, whatever the caller said.
+    Wanted = wanted(Limits, Inst),
     case start_compiler() of
         {ok, Pid} ->
             %% Started empty and then told what to do: passing the instance as a
             %% start argument would copy it into the supervisor as well, and a
             %% real instance is 35 MB.
-            Pid ! {compile, Inst, Limits, Executed},
+            Pid ! {compile, Inst, Limits, Wanted},
             true;
         %% Every slot is already being filled, so there is nothing for a
         %% seventeenth compiler to publish into. Give the ask back and let the

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -54,6 +54,7 @@ moved, because even with all three a refusal still interprets.
 """.
 
 -export([entry/3, after_call/2, counts/0, reset_counts/0, await/2, release/1]).
+-export([diagnostics/0, normalize_reason/1, shard_count/2, shards/1]).
 -export([reentered/0]).
 -export([compiler_loop/0]).
 -export([dump/1, dump/2]).
@@ -69,13 +70,11 @@ moved, because even with all three a refusal still interprets.
 
 %% Splitting a compile across units. The unit is what `compile:forms/2` is
 %% handed, and that call is 99.3% of the cost, so several of them run at once
-%% where one cannot. Sized in words of lowered IR because generated code is
-%% linear in that: 11 to 19 bytes of BEAM per word, near enough constant.
+%% where one cannot.
 %%
-%% The floor exists because a split is not free -- it takes a slot per unit out
-%% of a pool of sixteen that the whole node shares -- and a module that compiles
-%% in a second is not the problem. QuickJS's hot set is about 900,000 words.
--define(SHARD_WORDS, 150000).
+%% A split is not free -- it takes a slot per unit out of a pool of sixteen the
+%% whole node shares, and a call between units is a crossing rather than a call
+%% -- so it happens only when one unit will not fit. See `shard_count/2`.
 -define(MAX_SHARDS, 4).
 %% Set by `entry_1/3` when this call found the module hot and unbuilt, read by
 %% `after_call/2` once the call has finished. The invocation's own lifetime is
@@ -88,6 +87,18 @@ moved, because even with all three a refusal still interprets.
 -define(IX_ENTERED, 2).       % invocations that entered generated code
 -define(IX_REENTERED, 3).     % calls the interpreter made into generated code
 -define(IX_CACHED, 4).        % compilations answered from the on-disk cache
+-define(IX_REFUSED, 5).       % compiles this runtime declined to attempt
+-define(IX_FAILED, 6).        % compiles the OTP compiler rejected
+-define(IX_CRASHED, 7).       % compiles that died in an unexpected way
+%% Not a count. A sequence for `wasm_code_diag' keys, so two compilers can each
+%% record without a read-modify-write, and deliberately *not* cleared by
+%% `reset_counts/0': a row that outlived a reset must never collide with a key
+%% handed out afterwards.
+-define(IX_SEQ, 8).
+
+%% Reasons are normalised to a bounded shape before they are stored, so the
+%% ring's memory is fixed whatever a compiler hands back. The ring itself lives
+%% in `wasm_code_slots`, which owns the tier's tables.
 
 %%% ------------------------------------------------------------------ api ---
 
@@ -189,7 +200,9 @@ maybe_adopt(Inst, Limits, Entry) ->
                 {ok, _Mod} ->
                     case compile(Inst, Limits, [], adopt) of
                         {ok, Slot} -> compiled(Inst, Slot, Entry);
-                        error -> Entry
+                        %% An adoption never refuses and never fails: there is
+                        %% nothing to generate. Anything but a slot is `retry`.
+                        _ -> Entry
                     end;
                 %% Nothing to adopt. Ask once the call has finished and this
                 %% process knows which functions it needed.
@@ -226,7 +239,27 @@ counts() ->
     #{compiled => atomics:get(R, ?IX_COMPILED),
       entered => atomics:get(R, ?IX_ENTERED),
       reentered => atomics:get(R, ?IX_REENTERED),
-      cached => atomics:get(R, ?IX_CACHED)}.
+      cached => atomics:get(R, ?IX_CACHED),
+      refused => atomics:get(R, ?IX_REFUSED),
+      failed => atomics:get(R, ?IX_FAILED),
+      crashed => atomics:get(R, ?IX_CRASHED)}.
+
+-doc """
+Why the last compiles that did not happen did not happen.
+
+`counts/0` says how many were refused or failed; this says what they were.
+Oldest first, a bounded number of them, and every reason normalised to a
+bounded shape: a `{compile, _}` from the OTP compiler carries its whole
+diagnostic list and an exit reason carries a stacktrace, and neither belongs in
+a table that is read back for diagnosis.
+
+`crashed` compiles are counted and not listed, for the same reason.
+
+Answers `[]` rather than raising when the table is not there, which is what a
+node that loaded these modules without restarting the application has.
+""".
+-spec diagnostics() -> [{refused | failed, term(), term()}].
+diagnostics() -> wasm_code_slots:diagnostics().
 
 -doc "For tests, which need to count what one run did rather than what a node did.".
 -spec reset_counts() -> ok.
@@ -235,7 +268,12 @@ reset_counts() ->
     atomics:put(R, ?IX_COMPILED, 0),
     atomics:put(R, ?IX_ENTERED, 0),
     atomics:put(R, ?IX_REENTERED, 0),
-    atomics:put(R, ?IX_CACHED, 0).
+    atomics:put(R, ?IX_CACHED, 0),
+    atomics:put(R, ?IX_REFUSED, 0),
+    atomics:put(R, ?IX_FAILED, 0),
+    atomics:put(R, ?IX_CRASHED, 0),
+    %% `?IX_SEQ' is left alone on purpose: see its definition.
+    wasm_code_slots:clear_diagnostics().
 
 %%% -------------------------------------------------------------- entering ---
 
@@ -346,7 +384,7 @@ await_1(Inst, Deadline) ->
                 {ok, _Mod} ->
                     case compile(Inst, #{}, [], adopt) of
                         {ok, _Slot} -> ok;
-                        error -> retry(Inst, Deadline)
+                        _ -> retry(Inst, Deadline)
                     end;
                 error -> retry(Inst, Deadline)
             end;
@@ -383,13 +421,85 @@ ask(Inst, Limits) ->
     case maps:get(compile_sync, Limits, false) of
         %% Synchronous compilation, for callers that would rather wait than
         %% measure something half compiled. The conformance suite is one.
+        %%
+        %% It does not consult `ask_compile/1`, so a synchronous caller retries
+        %% on every call rather than once per retry interval. That is what
+        %% asking to compile synchronously means, and it is why the pacing in
+        %% `record/3` is described as covering the asynchronous path.
         true ->
-            _ = compile(Inst, Limits, wanted(Limits, Inst), generate),
+            record(Inst, Limits, compile(Inst, Limits, wanted(Limits, Inst),
+                                         generate)),
             ok;
         false ->
             _ = wasm_instance:ask_compile(Inst) andalso spawn_compile(Inst, Limits),
             ok
     end.
+
+%% Every outcome of a compile is counted here and nowhere else, so nothing can
+%% be counted twice.
+%%
+%% `compiled` is deliberately not among them: it counts *functions*, is bumped
+%% where they are published, and `{ok, Slot}` comes back from adopting somebody
+%% else's module as readily as from generating one.
+%%
+%% Only a `retry` gives the ask back. A refusal leaves the timestamp standing,
+%% because `release_ask/1` sets it to zero and the next hot call would then ask
+%% again immediately; left alone it expires after the retry interval, which is
+%% the pacing a refusal wants and already exists.
+%%
+%% `compile_force` raises *after* the outcome is recorded and outside any
+%% `try`, so a forced failure is one record and not a record plus a crash.
+record(Inst, Limits, Outcome) ->
+    case Outcome of
+        {ok, _Slot} -> ok;
+        retry -> wasm_instance:release_ask(Inst);
+        {refused, Reason} -> note(Inst, refused, ?IX_REFUSED, Reason);
+        {failed, Reason} ->
+            note(Inst, failed, ?IX_FAILED, Reason),
+            wasm_instance:release_ask(Inst)
+    end,
+    case Outcome of
+        {ok, _} -> ok;
+        retry -> ok;
+        {_, Why} -> forced(Limits) andalso erlang:error({compile_failed, Why}),
+                    ok
+    end,
+    Outcome.
+
+note(Inst, Outcome, Index, Reason) ->
+    bump(Index, 1),
+    wasm_code_slots:record_diagnostic(next_seq(), Outcome, key(Inst),
+                                      normalize_reason(Reason)),
+    ok.
+
+next_seq() -> atomics:add_get(counters(), ?IX_SEQ, 1).
+
+-doc """
+The bounded form of a compile failure's reason, as `diagnostics/0` keeps it.
+
+Bounded by structure, not by formatting. `io_lib:format("~P", [R, 8])` bounds
+*depth*: a flat million-character list at depth 8 still formats to a million
+bytes, and truncating afterwards has already built the whole thing. So the two
+shapes that carry unbounded data lose it here -- the OTP compiler's diagnostics
+become their count, an exit reason becomes its tag -- and anything unrecognised
+becomes an atom and nothing else.
+
+Exported because it is the guarantee `diagnostics/0` rests on, and a guarantee
+that cannot be checked directly is not one.
+""".
+-spec normalize_reason(term()) -> term().
+normalize_reason({limit, _} = R) -> R;
+normalize_reason({unsupported, _} = R) -> R;
+normalize_reason({compile, Errors}) when is_list(Errors) ->
+    {compile, length(Errors)};
+normalize_reason({compiler_died, Why}) when is_tuple(Why), tuple_size(Why) > 0 ->
+    case element(1, Why) of
+        Tag when is_atom(Tag) -> {compiler_died, Tag};
+        _ -> {compiler_died, other}
+    end;
+normalize_reason({compiler_died, Why}) when is_atom(Why) ->
+    {compiler_died, Why};
+normalize_reason(_) -> other.
 
 %% Which functions to compile: the ones that ran, or all of them.
 %%
@@ -449,22 +559,38 @@ The wait has a deadline for the same reason: a child whose sender died between
 compiler_loop() ->
     receive
         {compile, Inst, Limits, Executed} ->
-            try compile(Inst, Limits, Executed, generate) of
-                {ok, _Slot} -> ok;
-                %% No slot free, or another process got there first. Give the
-                %% ask back so this instance tries again when it next goes hot,
-                %% rather than waiting out the retry interval.
-                error -> wasm_instance:release_ask(Inst)
-            catch
-                %% A compile that fails must not leave the instance thinking it
-                %% has one in flight. This does not cover being killed, which
-                %% is what the ask expiring is for.
-                _:_ -> wasm_instance:release_ask(Inst)
+            %% The `try` covers the compile and nothing else. `record/3` runs
+            %% after it, so `compile_force`'s deliberate exception is not caught
+            %% here and counted a second time as a crash.
+            Outcome =
+                try compile(Inst, Limits, Executed, generate)
+                catch
+                    %% A compile that fails must not leave the instance thinking
+                    %% it has one in flight. This does not cover being killed,
+                    %% which is what the ask expiring is for.
+                    C:R ->
+                        bump(?IX_CRASHED, 1),
+                        wasm_instance:release_ask(Inst),
+                        {crashed, {C, R}}
+                end,
+            case Outcome of
+                {crashed, _} -> ok;
+                _ -> _ = record(Inst, Limits, Outcome), ok
             end
     after 30000 ->
         ok
     end.
 
+%% Every outcome is a value, and there are four of them:
+%%
+%%     {ok, Slot} | retry | {refused, Reason} | {failed, Reason}
+%%
+%% `retry` is nobody's fault -- no slot free, another process got there first,
+%% nothing eligible to compile -- and is retried at the next hot call. A refusal
+%% is this runtime declining, and is paced by the ask's own retry interval. A
+%% failure is the OTP compiler saying no. Nothing here raises for any of them,
+%% which is what let a refusal disappear before: the only exception the caller
+%% now sees is one nobody expected.
 compile(Inst, Limits, Executed, Mode) ->
     Key = key(Inst),
     case wasm_code_slots:claim_loading(Key, {instance, Inst#inst.id}, self()) of
@@ -480,8 +606,8 @@ compile(Inst, Limits, Executed, Mode) ->
             adopt(Inst, Mod);
         %% Somebody else is compiling this module. Interpreting is always
         %% correct, and waiting on another process's compilation is not.
-        loading -> error;
-        {error, no_slot} -> error;
+        loading -> retry;
+        {error, no_slot} -> retry;
         %% Nothing resident and a slot is free. In `adopt` mode that is not what
         %% was wanted: give the slot straight back rather than generate on a
         %% caller's process, which is the whole thing this asynchrony exists to
@@ -489,7 +615,7 @@ compile(Inst, Limits, Executed, Mode) ->
         %% it race-free.
         {compile, _Mod, Token} when Mode =:= adopt ->
             ok = wasm_code_slots:abort(Token),
-            error;
+            retry;
         {compile, Mod, Token} -> generate(Inst, Limits, Mod, Token, Executed)
     end.
 
@@ -497,8 +623,22 @@ generate(Inst, Limits, Mod, Token, Executed) ->
     case unit(Inst, Executed) of
         [] ->
             ok = wasm_code_slots:abort(Token),
-            error;
+            retry;
         Unit ->
+            generate_1(Inst, Limits, Mod, Token, Unit)
+    end.
+
+%% Refused before anything is generated when even `?MAX_SHARDS` units cannot
+%% hold it. `length/1` on the eligible list is the whole cost of finding out,
+%% and the alternative is discovering it inside `wasm_core:fun_name/1` after the
+%% Core Erlang for every function before the 2049th has been built.
+generate_1(Inst, Limits, Mod, Token, Unit) ->
+    N = length(Unit),
+    case N > ?MAX_SHARDS * map_get(max_funs, wasm_core:limits()) of
+        true ->
+            ok = wasm_code_slots:abort(Token),
+            {refused, {limit, {too_many_functions, N}}};
+        false ->
             %% `full` unless the caller asks for `baseline`, and this
             %% default has now moved three times. It is worth reading why,
             %% because the reason it moved back is not the reason it moved.
@@ -525,8 +665,15 @@ generate(Inst, Limits, Mod, Token, Executed) ->
             Mode = maps:get(compile_quality, Limits, full),
             {_Name, Gen} = Token,
             Stamp = stamp(Inst, Gen),
-            build(Inst, Limits, Mode, Stamp, Unit, split(Unit, Limits),
-                  [{Mod, Token}])
+            case split(Unit, Limits) of
+                %% Unreachable while `shard_count/2` asks for enough bins, and
+                %% still an outcome rather than a crash.
+                full ->
+                    ok = wasm_code_slots:abort(Token),
+                    {refused, {limit, {too_many_functions, N}}};
+                Parts ->
+                    build(Inst, Limits, Mode, Stamp, Unit, Parts, [{Mod, Token}])
+            end
     end.
 
 %% One unit or several, and the difference is only how many slots are held.
@@ -537,7 +684,7 @@ generate(Inst, Limits, Mod, Token, Executed) ->
 %% used sooner, because the functions worth compiling are the ones expensive to
 %% compile: sixteen of QuickJS's hot functions are already 30 seconds of the 54.
 %% See `test/audit/PERF.md`.
-build(Inst, Limits, Mode, Stamp, Unit, [_], [{Mod, Token}]) ->
+build(Inst, _Limits, Mode, Stamp, Unit, [_], [{Mod, Token}]) ->
     case artifact(Inst, Mod, Unit, Mode, Stamp, undefined, Mod, #{}) of
         {ok, Bin} ->
             {module, Mod} = code:load_binary(Mod, "wasm_generated", Bin),
@@ -546,8 +693,7 @@ build(Inst, Limits, Mode, Stamp, Unit, [_], [{Mod, Token}]) ->
             adopt(Inst, Mod);
         {error, Reason} ->
             ok = wasm_code_slots:abort(Token),
-            forced(Limits) andalso erlang:error({compile_failed, Reason}),
-            error
+            outcome(Reason)
     end;
 build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First]) ->
     %% Every slot claimed before anything is generated, because each unit names
@@ -557,7 +703,7 @@ build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First]) ->
     case claim_rest(Inst, length(Parts) - 1, [First]) of
         {error, Held} ->
             _ = [wasm_code_slots:abort(T) || {_, T} <- Held],
-            error;
+            retry;
         Tokens ->
             Mods = [M || {M, _} <- Tokens],
             Head = hd(Mods),
@@ -576,15 +722,21 @@ build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First]) ->
             publish_all(Inst, Limits, Tokens, Parts, Bins)
     end.
 
+%% Which of the two failure outcomes a reason is. A refusal is this runtime
+%% declining to compile something; a failure is the OTP compiler rejecting what
+%% it was given, or a compiler process dying under it.
+outcome({limit, _} = R) -> {refused, R};
+outcome({unsupported, _} = R) -> {refused, R};
+outcome(R) -> {failed, R}.
+
 %% All or nothing. A chain with a hole in it would answer `not_compiled` for
 %% every function past the hole, which is correct but is most of the work thrown
 %% away, and the slots would be held for it.
-publish_all(Inst, Limits, Tokens, Parts, Bins) ->
+publish_all(Inst, _Limits, Tokens, Parts, Bins) ->
     case [R || {error, _} = R <- Bins] of
         [{error, Reason} | _] ->
             _ = [wasm_code_slots:abort(T) || {_, T} <- Tokens],
-            forced(Limits) andalso erlang:error({compile_failed, Reason}),
-            error;
+            outcome(Reason);
         [] ->
             %% Every module loaded before any of them is published, and the two
             %% must not be interleaved.
@@ -611,55 +763,96 @@ publish_all(Inst, Limits, Tokens, Parts, Bins) ->
 %% the critical path here is one function whatever the split, so it is close to
 %% the best available.
 split(Unit, Limits) ->
-    Sized = [{erts_debug:flat_size(IR), U} || {_, _, _, IR} = U <- Unit],
-    case shards(lists:sum([W || {W, _} <- Sized]), Limits) of
+    case shard_count(length(Unit), Limits) of
         1 -> [Unit];
-        N -> renumber(bins(lists:reverse(lists:sort(Sized)), empty_bins(N)))
+        N ->
+            Sized = [{erts_debug:flat_size(IR), U} || {_, _, _, IR} = U <- Unit],
+            Cap = map_get(max_funs, wasm_core:limits()),
+            case bins(lists:reverse(lists:sort(Sized)), empty_bins(N), Cap) of
+                full -> full;
+                Parts -> renumber(Parts)
+            end
     end.
 
-%% `auto` is one, which is to say splitting is off unless you ask for it.
-%%
-%% It works, and what it buys and costs are both measured. QuickJS's
-%% 223-function hot set, background compiler, at the `full` quality that is now
-%% the default:
-%%
-%% | | compile | warm `_start` |
-%% | --- | ---: | ---: |
-%% | one unit | 129.3 s | 76.5 ms |
-%% | four units | **33.2 s** | **93.3 ms** |
-%%
-%% **3.9x faster to compile and about 22% slower to run.** The second half is a
-%% call between units going through `wasm_exec:shard_call/8` where a call within
-%% one is a local `apply`; it was 1.5x until those calls stopped going out
-%% through the interpreter and back in through the head of the chain.
-%%
-%% The default is one unit anyway, because the trade depends on something this
-%% module cannot know: ninety-six seconds saved against seventeen milliseconds a
-%% run is about five thousand six hundred invocations to break even. A worker
-%% that serves a module for a day should not split; something that compiles a
-%% module to run it a few times should. So it is `compile_shards`, and it is the
-%% embedder's call.
-shards(Words, Limits) ->
+-doc """
+How many units this many functions are split into.
+
+Pure, and exported so the policy can be asserted without running a compile.
+
+`wasm_core` draws every name a unit can use from a pre-generated pool, because
+nothing a guest supplies may become an atom, and that pool is `max_funs` deep.
+A unit past it is refused, so the split exists to keep each unit under it and
+for no other reason: a guest that fits in one unit stays in one unit and its
+generated code is unchanged.
+
+The answer is the number of bins *requested*. `bins/3` drops empty ones, so
+asking for four on a one-function unit gives one actual part; `shards/1` is
+what reports the actual count.
+""".
+-spec shard_count(non_neg_integer(), map()) -> pos_integer().
+shard_count(NFuns, Limits) ->
     case maps:get(compile_shards, Limits, auto) of
-        auto -> auto_shards(Words);
+        auto -> auto_shards(NFuns);
         N when is_integer(N), N >= 1 -> erlang:min(?MAX_SHARDS, N)
     end.
 
-auto_shards(_Words) -> 1.
+auto_shards(NFuns) ->
+    Max = map_get(max_funs, wasm_core:limits()),
+    case NFuns =< Max of
+        true -> 1;
+        false -> erlang:min(?MAX_SHARDS, (NFuns + Max - 1) div Max)
+    end.
 
-empty_bins(N) -> [{0, []} || _ <- lists:seq(1, N)].
+empty_bins(N) -> [{0, 0, []} || _ <- lists:seq(1, N)].
 
-bins([], Bins) ->
-    [lists:reverse(Us) || {_, Us} <- Bins, Us =/= []];
-bins([{W, U} | Rest], Bins) ->
-    [{Load, Us} | Others] = lists:sort(Bins),
-    bins(Rest, [{Load + W, [U | Us]} | Others]).
+%% The lightest bin *that can still take a function*, not the lightest bin.
+%%
+%% Balancing by words alone is right for wall clock and wrong for the bound:
+%% one QuickJS function is 98,191 words, so a word-balanced split will happily
+%% put fifty thousand small ones in the bin beside it and refuse a module that
+%% fits. The count travels in the bin so this stays one comparison rather than a
+%% `length/1` per placement.
+%%
+%% `full` when no bin can accept, which the caller turns into a refusal. It is
+%% unreachable while `shard_count/2` asks for enough bins, and it is here
+%% because a policy that computes a number the binning is free to ignore is not
+%% a bound.
+bins([], Bins, _Cap) ->
+    [lists:reverse(Us) || {_, _, Us} <- Bins, Us =/= []];
+bins([{W, U} | Rest], Bins, Cap) ->
+    case lists:splitwith(fun({_, N, _}) -> N >= Cap end, lists:sort(Bins)) of
+        {_Full, []} -> full;
+        {Full, [{Load, N, Us} | Others]} ->
+            bins(Rest, Full ++ [{Load + W, N + 1, [U | Us]} | Others], Cap)
+    end.
 
 %% `wasm_core` names functions by position in the unit, so each unit needs a
 %% dense range of its own.
 renumber(Parts) ->
     [[{Pos, Idx, F, IR} || {Pos, {_, Idx, F, IR}} <- lists:enumerate(0, P)]
      || P <- Parts].
+
+-doc """
+How many units this instance's module is actually resident in.
+
+Zero when nothing is compiled, and otherwise the length of the contiguous chain
+starting at shard one. `shard_count/2` says how many units were *asked* for;
+this says how many there are, which is what an acceptance run has to assert
+rather than infer from a wall time.
+""".
+-spec shards(#inst{}) -> non_neg_integer().
+shards(Inst) ->
+    case wasm_code_slots:lookup(key(Inst)) of
+        {ok, _} -> 1 + rest_shards(Inst, 2, 0);
+        _ -> 0
+    end.
+
+rest_shards(_Inst, N, Acc) when N > ?MAX_SHARDS -> Acc;
+rest_shards(Inst, N, Acc) ->
+    case wasm_code_slots:lookup(shard_key(Inst, N)) of
+        {ok, _} -> rest_shards(Inst, N + 1, Acc + 1);
+        _ -> Acc
+    end.
 
 %% Shard one keeps the module's own key, so `maybe_adopt/3` finds a compiled
 %% module by asking the same question it always did.
@@ -908,13 +1101,13 @@ counters() ->
     case persistent_term:get(?PT_COUNTS, undefined) of
         undefined -> fresh_counters();
         R ->
-            case maps:get(size, atomics:info(R)) >= ?IX_CACHED of
+            case maps:get(size, atomics:info(R)) >= ?IX_SEQ of
                 true -> R;
                 false -> fresh_counters()
             end
     end.
 
 fresh_counters() ->
-    R = atomics:new(?IX_CACHED, [{signed, false}]),
+    R = atomics:new(?IX_SEQ, [{signed, false}]),
     persistent_term:put(?PT_COUNTS, R),
     R.

--- a/src/wasm_store.erl
+++ b/src/wasm_store.erl
@@ -52,7 +52,7 @@ reset instead of a permanent leak. See `wasm_keeper:init/1`.
 %% Named rather than derived, because a table this does not know about is one
 %% nothing gives a lifetime to. Adding a long-lived table means adding it here.
 -define(TABLES, [wasm_holders, wasm_tables, wasm_waiters,
-                 wasm_code_slots, wasm_code_calls]).
+                 wasm_code_slots, wasm_code_calls, wasm_code_diag]).
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/src/wasm_validate.erl
+++ b/src/wasm_validate.erl
@@ -299,9 +299,22 @@ check_type_index(T, Ctx) ->
 %% A declared supertype has to be one: the type must actually be structurally
 %% below it, the supertype must exist and must not be final, and it must be
 %% declared before this one so the relation cannot be circular.
+%%
+%% And there may be at most one of them. The binary format encodes the
+%% supertypes as a vector, which is what makes two of them decodable, and the
+%% specification bounds that vector at one; `type-subtyping.wast` asserts it as
+%% "multiple supertypes". Without this a module declaring two parents was
+%% accepted and each parent checked on its own, which is a coherent thing to do
+%% and not what the language says.
 check_subtypes(#module{types = Types}, #ctx{types = T, canon = C} = Ctx) ->
     lists:foreach(
       fun({I, #subtype{supers = Supers, body = Body}}) ->
+              case Supers of
+                  [_, _ | _] ->
+                      invalid(multiple_supertypes, <<"multiple supertypes">>,
+                              #{type => I, count => length(Supers)});
+                  _ -> ok
+              end,
               lists:foreach(
                 fun(Sup) ->
                         check_super(I, Sup, Body, T, C, Ctx)

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -469,3 +469,20 @@ nothing.** It answers 0 rather than an error, and `trace_info/2` then reads
 failure. `bench/paths/tiered.erl` never hit this because it warms the workload
 first; anything that sets the pattern before the first call has to
 `code:ensure_loaded/1` and match the 1 that `trace_pattern/3` returns.
+
+**A trace pattern set on a module the emulator has not loaded, twice in one
+session.** The second time it produced a whole wrong mechanism. Probing why a
+compilation never happened, `erlang:trace_pattern({wasm_jit, compile, 4}, MS,
+[local])` answered **0** because `wasm_jit` was not yet loaded, so `compile/4`
+never appeared in the trace and the conclusion was "the worker never received
+its work, so the ask dies with the process that raised it". That went into
+`PERF.md` as a finding.
+
+With `code:ensure_loaded/1` first and the pattern's return matched against 1,
+the same arm shows `compile/4` entered and the compiler still running at 45
+seconds. The real answer was that QuickJS takes 165 seconds to compile and the
+watch had been given 60, and that CPython threw `{limit, too_many_functions}`.
+
+Match the 1. `trace_pattern/3` returning 0 and `trace_info/2` reading
+`undefined` are the same shape as a runtime that does nothing, and a trace that
+matches nothing will confirm any story told about it.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -486,3 +486,17 @@ watch had been given 60, and that CPython threw `{limit, too_many_functions}`.
 Match the 1. `trace_pattern/3` returning 0 and `trace_info/2` reading
 `undefined` are the same shape as a runtime that does nothing, and a trace that
 matches nothing will confirm any story told about it.
+
+**Pointing `compile_whole` at CPython.** With the name pool at 4096 the
+four-unit ceiling is 16,384, so CPython's 11,447 eligible functions are no
+longer refused and the compiler starts on all of them. It reached **33 GB
+resident on a 48 GB box in eleven minutes**, with 66 MB of memory free, 0% CPU
+because it was paging rather than compiling, and nothing published. Killed.
+
+The ceiling bounds the *names* a unit may use. It says nothing about whether
+`compile:forms/2` can build what is under it, and for a 25 MB guest it cannot.
+`docs/compiled-tier.md` already called the option affordable only on
+specification modules; this is the number behind that sentence.
+
+Compiling what ran, which every default does, is 2,333 functions, 1,105 seconds
+and a fraction of the memory.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -442,3 +442,30 @@ instruction keeps. `run_case/3` flags anything under 0.05 ns, which catches the
 first three failures and not the fourth; the fourth is caught only by reading
 each unsigned row against its signed twin, which is why they are laid out in
 pairs. Four rows already in that file trip the flag.
+
+**Measuring lowering with the sizing instrument still in the window.** The
+experiment that reported lowering at 39% of a QuickJS request had the isolation
+right and the build wrong: the cold arm ran an instrumented `wasm_instance`
+whose `body_of/2` called `erts_debug:size/1` on every lowered body, and the
+pre-lowered arm ran the same call in its setup, where nothing is counted. The
+difference between the arms was the instrument, not the runtime.
+
+`erts_debug:size/1` allocates 172 words for every word of term it walks:
+34,490,334 words a call on a 200,000-word list. On 725,535 words of retained IR
+that is the whole 20.6 M the experiment attributed to lowering. Clean, lowering
+is 764,533 words, 2.7%.
+
+Nothing in the run looked wrong. Both arms produced the right reply, the
+estimator validates to 0.0%, the pre-lowering demonstrably happened, and the
+two numbers were 20 M apart. A subtraction between two arms is only as clean as
+the code they *both* load: a module reached through `-pa` is part of the
+measurement. `bench/paths/pyarms.erl` prints `code:which/1` for `wasm_exec`,
+`wasm_instance` and `wasm_jit` on every arm, and reproduces both the wrong and
+the right numbers by that path alone.
+
+**`erlang:trace_pattern/3` on a module the emulator has not loaded matches
+nothing.** It answers 0 rather than an error, and `trace_info/2` then reads
+`undefined`, so a dispatch count comes back as a missing value instead of a
+failure. `bench/paths/tiered.erl` never hit this because it warms the workload
+first; anything that sets the pattern before the first call has to
+`code:ensure_loaded/1` and match the 1 that `trace_pattern/3` returns.

--- a/test/audit/ATTEMPTS.md
+++ b/test/audit/ATTEMPTS.md
@@ -500,3 +500,21 @@ specification modules; this is the number behind that sentence.
 
 Compiling what ran, which every default does, is 2,333 functions, 1,105 seconds
 and a fraction of the memory.
+
+**A `max_heap_size` fuse on the compiler.** The plan was to cap whatever runs
+`compile:forms/2` so a guest nobody anticipated dies as a killed compiler rather
+than as a paging node. Measured on QuickJS at one unit, the process `wasm_jit`
+spawns peaks at **0.34 GB of heap** while the node reaches 6.19 GB: the work is
+not there. `compile:forms/2` spawns a process of its own by default and runs
+everything in it, and nothing we set reaches that child.
+
+`no_spawn_compiler_process` moves the work into our process, where the cap can
+see it -- 4.16 GB -- and costs **293 seconds against 167**, on the same box at
+the same load. The child was never collecting: it allocates, returns the binary
+and exits, and a dying process frees its heap for free. Living through the
+allocation means paying for the collections.
+
+A fuse that sees 0.34 GB of a 6 GB compile is not a fuse, and 75% of compile
+time is too much to buy one. Neither shipped. What is left open is bounding
+compile memory at all, and the obstacle is not the number: it is that the memory
+is spent in a process only the OTP compiler can configure.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3700,3 +3700,48 @@ instruction implies about 270 M instructions, which at 35 seconds interpreted is
 the 80% the plan requires, and no change should be made on the strength of this
 table alone. What it does say is which candidate to price first: not rebuilding
 interpreter state per instruction.
+
+### The model closes at 50%, and the missing half is not dispatch at all
+
+Price times frequency, on QuickJS serving one JSON line. The histogram comes
+from a throwaway `wasm_exec` whose 123 `run/3` clause heads are renamed and
+wrapped by a counting one, so every dispatch is counted and the tail calls are
+kept:
+
+| | words |
+| --- | ---: |
+| measured allocation | 33,128,640 |
+| model, 11 a dispatch and 7 a block | 16,660,622 |
+| **closure** | **50.3%** |
+
+1,618,706 dispatches over 89 distinct opcodes, `block` the largest single one at
+17.69%. The plan's bar is 80%, so by its own rule nothing gets optimised on
+this.
+
+**Where the other half is.** Three stages, each a fresh process, each doing
+strictly more than the last, so every component is a difference:
+
+| stage | words |
+| --- | ---: |
+| instantiate only | 137,673 |
+| instantiate + one request | 33,138,857 |
+| instantiate + two requests | 33,744,447 |
+| **marginal second request** | **605,590** |
+| **premium paid by the first request** | **32,395,594** |
+
+**A second identical request costs 605 K words against the first request's
+33 M.** Ninety-eight per cent of what a `_start` guest allocates is paid once,
+and the steady state the dispatch model prices is under two per cent of it.
+
+**What the 32.4 M is, and what it is not.** `_start` is one call that serves
+every line and exits, so "two requests" is one start-up serving two, and the
+premium is everything the first request pays that the second does not: this
+runtime's lazy IR lowering *and* QuickJS parsing `worker.js` and building its
+own JS runtime. **This experiment cannot separate those two**, and the earlier
+line in this file calling it "lowering" would be wrong. Separating them needs
+lowering counted where it happens, in `wasm_instance:body_of/2`.
+
+That reorders the candidates in the plan's step 3. Not rebuilding `#st{}` per
+instruction is a real cost and the right target for a long-running guest; for a
+one-shot `wasm32-wasi` command, which is most of what a toolchain emits, it is
+under two per cent and the one-time path is the whole thing.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3653,3 +3653,50 @@ end of file at once and returned in 19 ms with no reply: a 16x speedup that was
 a guest doing nothing, which is why the reply assertion is in the harness. And
 an earlier diagnosis that "the ask dies with the process" was wrong:
 `wasm:call/3` runs `after_call/2` at depth 0 before the caller moves on.
+
+## Where the words go: an 11-word record, rebuilt once per instruction
+
+The price half of the attribution. `bench/paths/perinstr.erl` gained the same K
+against 2K differential on **allocated words**, taken from `allocwords` rather
+than the node-wide counter. Interpreter, words per snippet and per instruction:
+
+| snippet | words/snip | words/instr |
+| --- | ---: | ---: |
+| `nop` | **0.00** | **0.00** |
+| `block`, empty | 7.00 | 7.00 |
+| `block` x8 nested | 56.00 | 7.00 |
+| `local.get` + `drop` | 24.00 | 12.00 |
+| `i32.const` + `drop` | 24.00 | 12.00 |
+| `i32.add` | 19.00 | 4.75 |
+| `i32.mul` | 19.00 | 3.17 |
+| `i32.load` | 19.00 | 6.33 |
+| `i64.load` | 45.00 | 15.00 |
+| `global.set` | 40.00 | 20.00 |
+| `call`, empty function | 34.00 | 34.00 |
+| `call_indirect` | 67.00 | 33.50 |
+| `memory.copy`, 8 B and 1024 B | 55.00 | 13.75 |
+
+**`nop` allocates nothing and everything else allocates about twelve words an
+instruction, whatever it computes.** That rules out dispatch, the arithmetic and
+the operand stack in one reading: a cons cell is two words, and a push with a
+pop costs twenty-four.
+
+`#st{}` has ten fields, so `St#st{stack = S}` allocates **eleven words**, the
+tag and ten fields, and the interpreter writes one per instruction. That is the
+floor the table is made of. `memory.copy` costing the same for 8 bytes as for
+1024 is the same story from the other side: the copy is not on the process heap
+and the record update is.
+
+Blocks are cheaper because a control frame is not a whole `#st{}`, and they are
+the ones that add up: `PERF.md` records QuickJS entering **132,583,392 blocks**
+in a run, which at seven words is 928 M words from `block` alone.
+
+Against the measured 5.45 G words for a CPython start-up, twenty words an
+instruction implies about 270 M instructions, which at 35 seconds interpreted is
+130 ns each and agrees with the timing table.
+
+**This is the price half only.** The executed histogram keyed by
+`{FunctionIndex, OpcodeTag}` is not built yet, so the model does not close to
+the 80% the plan requires, and no change should be made on the strength of this
+table alone. What it does say is which candidate to price first: not rebuilding
+interpreter state per instruction.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4016,3 +4016,30 @@ interpreted dispatch, and generated code does not allocate it.
 | wall | 53 ms to 16 ms | 19.2 s to 4.9 s |
 | functions compiled | 402 | 2,333 |
 | compile time, once | 165 s | 464 s |
+
+### The disk cache saves 4% of a sharded compile
+
+Sharding is what gets CPython compiled, and it is also what stops the artifact
+being reusable. `wasm_jit:artifact/8` caches a unit only when it is the last in
+the chain:
+
+    %% Not cached when it is one of several. The key would have to carry which
+    %% module the chain points at next, and a shard set is only reproducible if
+    %% the same split falls out of the same workload, which nothing promises.
+
+Four shards, so one is written and three are rebuilt on every emulator. Measured
+by running the same arm twice against the same cache directory:
+
+| | cold cache | warm cache |
+| --- | ---: | ---: |
+| time to compiled | 464 s | **446 s** |
+| `cached` | 0 | 1 |
+| files in the cache directory | 1 | 1 |
+
+Which makes the on-disk cache worth **4%** here, and the whole 464 seconds is
+paid again by every node that runs this guest. For QuickJS, which fits in one
+unit, the same cache is worth the entire 165 seconds.
+
+So the two mechanisms that would make a large guest cheap are mutually
+exclusive as they stand: a module small enough to cache is one that fits under
+`?MAX_FUNS`, and a module that needs sharding to fit cannot be cached.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4222,3 +4222,57 @@ ran, which is what every default does, is 2,333 functions and 1,105 seconds in
 Recorded because the alternative is somebody discovering it on a production
 node. The ceiling is a bound on names, not a promise that everything under it
 compiles.
+
+### `max_depth` did not survive a tier boundary
+
+Two mutually recursive functions, `max_depth => 1000`, one program, three ways of
+running it:
+
+| arm | deepest recursion that returns | counters |
+| --- | ---: | --- |
+| both interpreted | 999 | -- |
+| both compiled | 1,000 | `compiled 2, reentered 0` |
+| **one compiled, one interpreted** | **99,999**, the search ceiling | `compiled 1, entered 18, reentered 799,994` |
+
+The third row is unbounded recursion for an untrusted guest, bounded only by BEAM
+memory. **Four separate breaks**, and the first two are the ones the measurement
+found:
+
+1. `call_out/7` reduced the *ceiling* on the way out, and `init_state/4`
+   discarded it: with a `?BUDGET` present, which it always is under
+   `wasm:call/4`, both the depth and the ceiling come from the budget. Coming
+   back, `do_call/4` handed a depth relative to that interpreter run to a check
+   against an absolute ceiling. Each round trip started again.
+2. `check_depth(Inst, G0#g.d)` validated the *caller's* depth where `enter/5`
+   validates the depth of the frame doing the calling. `invoke_fn/4`'s own
+   comment says the argument is the caller's, so a generated function's own depth
+   is `deeper(G0)`, and compiled code got one frame more than interpreted. That
+   is the 1,000 against 999.
+3. `indirect_out/9`'s foreign branch ignored its `Depth` entirely, and
+   `foreign_call/5` never published the caller's, so **two instances calling each
+   other through a shared table evaded the limit the same way**: 8 and 9 frames
+   both returned against a limit of 8.
+4. Found while fixing the others: the interpreter checks before creating an
+   *interpreted* frame and did not before entering a *compiled* one. Generated
+   code checks before its own calls, not on entry, so a callee that returned
+   without calling sat one frame past the limit unnoticed. The mixed arm bounded
+   at 9 where both pure arms bounded at 8.
+
+All four now bound at the same frame. The fix is one helper -- publish the
+crossing depth into the budget, restore **only that field** afterwards, `after`
+so a trap restores it too. Only that field because the nested run raises fuel
+through `publish_fuel/1` and the host-call count through `charge_host_call/1`;
+putting the whole tuple back would let a compiled function reset
+`max_host_calls` by crossing out and returning.
+
+A per-call `max_depth` still cannot reach generated code, which reads its ceiling
+from the instance. Rather than put a process-dictionary read inside
+`check_depth/2`, on the compiled call path, `entry/3` refuses compiled entry when
+the call overrides it -- the same thing it already does for finite fuel.
+
+**Left open, and named rather than hidden.** A foreign callee that spends fuel
+and then throws loses its final fuel value: only `leave/2` publishes, and
+`uncaught/1` is `erlang:throw({wasm_exception, Exn})` and nothing else. And
+`foreign_call/5` reads the callee's *committed* `#mut{}`, so an A -> B -> A
+recursion does not see A's in-flight state, and the exception branch drops
+mutations B made before throwing. Neither is visible to a depth test.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3745,3 +3745,48 @@ That reorders the candidates in the plan's step 3. Not rebuilding `#st{}` per
 instruction is a real cost and the right target for a long-running guest; for a
 one-shot `wasm32-wasi` command, which is most of what a toolchain emits, it is
 under two per cent and the one-time path is the whole thing.
+
+### Lowering is 39% of a request, and sizing its output misses that by 28x
+
+Counting `wasm_instance:body_of/2` cache misses says how often lowering happens
+and nothing about what it costs, and sizing the IR it produces with
+`erts_debug:size/1` measures only what it *keeps*. On QuickJS that retained
+figure is 725,535 words over 402 functions, which is 2% of the run and looks
+like an answer.
+
+Isolating it properly means moving it out of the window rather than measuring
+it: discover which functions a deterministic request reaches, then on a fresh
+instance lower exactly those **before the window opens**, in the same process,
+because the IR cache is keyed on the instance and lives in the process
+dictionary. Both arms then pay the guest's own start-up and the interpreter's
+dispatch, and only the cold one pays lowering.
+
+| arm | words |
+| --- | ---: |
+| cold, lowering inside the window | 52,837,237 |
+| warm, reached set pre-lowered | 32,231,161 |
+| **lowering** | **20,606,076, 39.0% of the run** |
+
+**Lowering allocates about twenty-eight words of garbage for every word of IR
+it retains.** Nothing that sizes the result can see that, which is why the
+retained figure is in this file as a trap and not as a measurement.
+
+`allocwords:measure/3` exists for this: it runs a setup in the measured process
+with tracing off, and opens the window only once the setup has returned. The
+first attempt at this experiment put the pre-lowering inside the measured fun,
+so both arms paid it and the difference came out at **4,176 words, 0.0%** -- a
+confident null result produced by a window that was open too early.
+
+### Where the run goes, so far
+
+| component | words | share | how it was separated |
+| --- | ---: | ---: | --- |
+| lowering | 20.6 M | 39% | pre-lowered outside the window |
+| dispatch, `#st{}` at 11 a time | 16.7 M | 32% | executed histogram times measured price |
+| retained IR, inside the 20.6 M above | 0.7 M | 2% | `erts_debug:size/1` |
+| instantiation | 0.14 M | 0.4% | staged measurement |
+| **accounted** | **37.3 M** | **~71%** | |
+
+Against the plan's 80% bar this is not finished, and the remainder is not yet
+named. What it does settle is the ranking: lowering first, dispatch second, and
+both of them ahead of anything else that has been proposed.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3441,3 +3441,45 @@ on identical work. `benchlib:in_process/1` gives each iteration a fresh
 *process*, which is right and is not enough; the emulator is the thing that has
 to be stated. Two `rebar3 eunit` runs of the same four cases came out at 16.8
 and 61.5 seconds before this was understood.
+
+## `load/1` is 4.6x slower than `compile/1` on a large guest
+
+The section above left the 227 MB process heap as the underlying defect, and
+the obvious fix is the one this runtime already implements: `wasm:load/1` puts
+the decoded module in `persistent_term`, where reads do not copy and the
+collector never scans it. `wasm.erl` says so too, in `load/1`'s own doc: "Use
+this rather than `compile/1`."
+
+On CPython that advice is expensive. Same harness, same guest, same three runs
+in one emulator, the only difference being which function built the module:
+
+| | `compile/1` | `load/1` |
+| --- | ---: | ---: |
+| peak process heap | 227 MB | **22 MB** |
+| wall, run 1 | 32,989 ms | 33,855 ms |
+| wall, run 2 | **13,763 ms** | 66,448 ms |
+| wall, run 3 | **14,172 ms** | 64,009 ms |
+| in GC, run 2 | 867 ms, 6.3% | 50,434 ms, **75.9%** |
+| minor, run 2 | 1,129 | 11,130 |
+| major, run 2 | **1** | **5,553** |
+
+**Getting the module off the process heap works, and costs 4.6x.** The heap
+does drop by ten times, exactly as the theory says. The collection it was
+supposed to save then arrives thirty times over: 5,553 major collections
+against one, and three quarters of the run spent collecting.
+
+It also inverts the cold and warm pattern the section above measured. Under
+`compile/1` the first run is the slow one and the rest are 2.4x faster; under
+`load/1` the first run is the *fast* one at 33.9 seconds and the later ones are
+64 to 66.
+
+So the 227 MB heap is not what the time is going on, and "keep the large term
+off the process heap" is the right general principle and the wrong fix here.
+The mechanism is not established. The per-process lowered-IR cache
+(`{wasm_ir, Id, Idx}`) is the first suspect, since it is the one thing that
+holds derived data per process and its contents depend on whether the module it
+was built from is heap data or a literal.
+
+**Until it is, `load/1`'s doc oversells itself on a large module.** It is right
+about what it was written about, which is not paying to decode the same bytes
+twice; it is wrong if read as advice for the steady state.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3934,3 +3934,32 @@ process, one `_start`, exit. Such a worker cannot warm anything, not even for
 the next process, which is why priming in `bench/paths/pyarms.erl` runs in the
 process that outlives it. Any prewarming design has to hold the asking process
 open until the compiler has the work.
+
+### A fresh instance that adopts before its first `_start` allocates 1.9% as much
+
+QuickJS, same guest and same request, measured the same way. The first arm is
+the cold interpreted run; the second is a fresh instance in a fresh process,
+after the module has been compiled, entering generated code on its **first and
+only** call:
+
+| | cold, interpreted | adopted before `_start` |
+| --- | ---: | ---: |
+| allocated | 28,145,449 | **532,789** |
+| collections | 32 minor, 14 major | 0 minor, 1 major |
+| clean wall | 53 ms | **16 ms** |
+| `entered` | 0 | **1** |
+
+**98.1% of the allocation is gone**, and the wall with it, 3.3x. The arm is not
+readable from the wall alone, which is why `entered` is in the table: it is 1,
+so this instance ran generated code on its first call, which is the thing that
+was in doubt.
+
+Compiling 402 functions took **165 seconds** and produced a 13.5 MB `.beam`,
+written to the on-disk cache. The cost is paid once per module, per runtime and
+per OTP version; the second emulator to see that module reads it back.
+
+This is the answer to the allocation question the whole investigation has been
+asking. The 5.45 G words CPython allocates are the interpreter executing 383
+million operations, and generated code does not allocate them. Nothing else
+measured -- lowering, decoding, validation, instantiation, the request itself --
+is worth one per cent.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3907,3 +3907,30 @@ validating, instantiating and the request itself, all of them together, cannot
 pay for more than a rounding error of a CPython cold start. The only lever with
 the right order of magnitude is not executing those 383 million operations
 interpreted.
+
+### The ask does not survive the process that raised it
+
+A one-call guest asks for compilation when `_start` finishes. If the process
+that made that call then exits, **nothing is compiled**, and nothing reaches the
+on-disk cache either.
+
+Three variants of the same QuickJS priming call, watched through
+`supervisor:count_children(wasm_jit_sup)` and a call trace on `wasm_jit:compile/4`
+and `wasm_instance:release_ask/1`:
+
+| priming call runs in | workers after 30 s | `compile/4` entered | compiled |
+| --- | ---: | --- | --- |
+| the process that stays alive | 1, still 1 at 105 s | yes | yes |
+| a spawned process kept alive | 1, still 1 at 105 s | yes | yes |
+| a spawned process that exits | **0** | **never** | **no** |
+
+The worker is started -- `spawn_compile/2` gets its `{ok, Pid}` -- and then never
+receives its work, exiting on `compiler_loop/0`'s 30-second `after`. It is not a
+compile that failed: `compile/4` is never entered and `release_ask/1` is never
+called, so the ask is not given back either.
+
+This is exactly the shape of every `wasm32-wasi` command-line worker: one
+process, one `_start`, exit. Such a worker cannot warm anything, not even for
+the next process, which is why priming in `bench/paths/pyarms.erl` runs in the
+process that outlives it. Any prewarming design has to hold the asking process
+open until the compiler has the work.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4138,3 +4138,87 @@ unit, the same cache is worth the entire 165 seconds.
 So the two mechanisms that would make a large guest cheap are mutually
 exclusive as they stand: a module small enough to cache is one that fits under
 `?MAX_FUNS`, and a module that needs sharding to fit cannot be cached.
+
+### Making CPython fit one unit, and the cache that follows
+
+The two mechanisms stopped excluding each other by making the guest fit. The
+name pool went from 2048 to **4096**, so CPython's 2,333 executed functions are
+one unit rather than two, and a unit that ends its chain is the one
+`wasm_jit:artifact/8` will cache.
+
+**What the pool costs**, measured in a clean emulator per arm, separate builds
+rather than two pools in one node, `wasm_core` loaded and then `atoms/0` forced:
+
+| | 2048 + 512 | 4096 + 512 | change |
+| --- | ---: | ---: | ---: |
+| atoms created | 2,881 | 4,929 | +2,048 |
+| `erlang:memory(atom)` | +116,592 B | +155,504 B | **+38,912 B** |
+| `erlang:memory(atom_used)` | +116,540 B | +155,452 B | +38,912 B |
+| `erlang:memory(total)` | +271,768 B | +324,240 B | +52,472 B |
+| naming every slot again | 0 further atoms | 0 further atoms | -- |
+
+38 KB of atom memory, node-wide, paid lazily on the first compile. The
+alternative was `?MAX_SHARDS`, which reaches the same 16,384 ceiling and cannot
+do this job at all: more shards cannot make a 2,333-function set *one* unit, so
+it cannot make the artifact cacheable, and it spends code slots, of which the
+node has sixteen.
+
+**What one unit buys.** CPython, `auto`, fresh instance entering generated code
+on its first `_start`:
+
+| units | allocated | clean wall | time to compiled | load |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 305,591,745 | 4,851 ms | 464 s | 13.24 |
+| 2 | 259,856,472 | 4,813 ms | 637 s | 4.73 |
+| **1** | **217,071,655** | **3,704 ms** | **1,105 s** | 3.11 |
+
+Monotone, and for the reason the four-shard arm already suggested: a call
+between units crosses through `wasm_exec:shard_call/8` and a call inside one
+does not. **29% less allocation in one unit than in four**, at the price of a
+compile with no parallelism left in it.
+
+**The allocation column is the claim; the wall column is not.** Each row is one
+run in its own emulator, not five interleaved pairs in both orderings, so it does
+not meet this file's bar for a speed claim and none is made. Allocated words are
+what the change is being judged on and they do not care about the load average.
+The three configurations cost about 40 minutes of compiling between them, on a
+box shared with other work, which is why the protocol was not run; it is the
+measurement to add if the wall difference ever has to be relied on.
+
+**And the compile is now paid once per node, not once per start.** A second
+emulator against the same cache directory:
+
+| | cold | warm |
+| --- | ---: | ---: |
+| time to compiled | 1,105 s | **2 s** |
+| `cached` | 0 | **1** |
+| shards resident | 1 | 1 |
+| `entered` on the first `_start` | 1 | 1 |
+| clean wall | 3,704 ms | 3,812 ms |
+
+The artifact is an 80 MB `.beam`. That is the item this file listed as open --
+"the compile recurs per node" -- closed for this guest, and closed by making it
+fit rather than by making the chain cacheable.
+
+**`compile_whole` on CPython does not finish, and the reason is memory.** With
+the pool at 4096 the ceiling is 16,384, so CPython's 11,447 eligible functions
+are no longer refused: `shard_count/2` asks for three units and the compiler
+starts. It was stopped after eleven minutes, not for being slow but for what it
+was doing to the box:
+
+| | |
+| --- | --- |
+| resident | **33 GB**, still climbing, on a 48 GB machine |
+| free memory | 66 MB |
+| CPU | 0%, so the time was paging and not compiling |
+| progress | `compiled => 0` at 600 s, nothing published |
+
+So the option is affordable exactly where `docs/compiled-tier.md` already says it
+is -- specification modules of a few functions each -- and the ceiling no longer
+refusing a 25 MB guest is not an invitation to point it at one. Compiling what
+ran, which is what every default does, is 2,333 functions and 1,105 seconds in
+16 GB less than this consumed before it was killed.
+
+Recorded because the alternative is somebody discovering it on a production
+node. The ceiling is a bound on names, not a promise that everything under it
+compiles.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3746,47 +3746,92 @@ instruction is a real cost and the right target for a long-running guest; for a
 one-shot `wasm32-wasi` command, which is most of what a toolchain emits, it is
 under two per cent and the one-time path is the whole thing.
 
-### Lowering is 39% of a request, and sizing its output misses that by 28x
+### Lowering is 2.7% of a request, and the 39% was the instrument
 
-Counting `wasm_instance:body_of/2` cache misses says how often lowering happens
-and nothing about what it costs, and sizing the IR it produces with
-`erts_debug:size/1` measures only what it *keeps*. On QuickJS that retained
-figure is 725,535 words over 402 functions, which is 2% of the run and looks
-like an answer.
+An earlier version of this section reported lowering at **20,606,076 words,
+39.0% of a QuickJS request**, and said lowering allocates twenty-eight words of
+garbage per word of IR it keeps. **Both numbers were the measuring instrument.**
+They are kept here with the correction because the way they went wrong is the
+useful part.
 
-Isolating it properly means moving it out of the window rather than measuring
-it: discover which functions a deterministic request reaches, then on a fresh
-instance lower exactly those **before the window opens**, in the same process,
-because the IR cache is keyed on the instance and lives in the process
-dictionary. Both arms then pay the guest's own start-up and the interpreter's
-dispatch, and only the cold one pays lowering.
+The isolation itself was right: discover which functions a deterministic request
+reaches, then on a fresh instance lower exactly those **before the window
+opens**, in the same process, because the IR cache is keyed on the instance and
+lives in the process dictionary. What was wrong is that the run carried an
+instrumented `wasm_instance` whose `body_of/2` called `erts_debug:size/1` on
+every lowered body, to report how many words the IR retained. In the cold arm
+that call is inside the window. In the pre-lowered arm it is inside the setup,
+where nothing is counted. The difference between the arms was therefore mostly
+the instrument.
+
+**`erts_debug:size/1` allocates, and not a little.** Ten calls on a
+200,000-word list, measured with `allocwords`:
+
+| | |
+| --- | ---: |
+| term walked | 200,000 words |
+| allocated per call | 34,490,334 words |
+| **per word of term** | **172 words** |
+
+At 725,535 words of retained IR that is enough to account for the whole
+20.6 M, and the "twenty-eight words per word kept" ratio was reading the
+instrument's own cost back as the runtime's.
+
+**The clean numbers.** Same harness, same arms, `bench/paths/pyarms.erl`, with
+nothing instrumented in the window:
 
 | arm | words |
 | --- | ---: |
-| cold, lowering inside the window | 52,837,237 |
-| warm, reached set pre-lowered | 32,231,161 |
-| **lowering** | **20,606,076, 39.0% of the run** |
+| cold, lowering inside the window | 28,145,449 |
+| pre-lowered, every function lowered in the setup | 27,380,916 |
+| **lowering of the reached set** | **764,533, 2.7% of the run** |
 
-**Lowering allocates about twenty-eight words of garbage for every word of IR
-it retains.** Nothing that sizes the result can see that, which is why the
-retained figure is in this file as a trap and not as a measurement.
+Which agrees with the retained figure it was supposed to contradict: 764,533
+allocated against 725,535 retained for the same 402 functions. Lowering keeps
+almost everything it allocates.
 
-`allocwords:measure/3` exists for this: it runs a setup in the measured process
-with tracing off, and opens the window only once the setup has returned. The
-first attempt at this experiment put the pre-lowering inside the measured fun,
-so both arms paid it and the difference came out at **4,176 words, 0.0%** -- a
-confident null result produced by a window that was open too early.
+Priced on its own, in a window holding nothing else, all 1530 QuickJS functions
+lower for **2,005,901 words** and retain 1,103,338 of them. Transient garbage is
+0.8 words per word kept, not 28.
+
+**The old numbers reproduce exactly when the instrumented modules are put
+back.** Same `pyarms` arms, `-pa` pointed at the instrumented build:
+
+| arm | clean | instrumented |
+| --- | ---: | ---: |
+| cold | 28,145,449 | 52,832,905 |
+| pre-lowered | 27,380,916 | 32,209,799 |
+| difference | 764,533 | 20,623,106 |
+
+against the 20,606,076 the original experiment reported. That is the same
+number, so the correction is not a difference of runs.
+
+**The rule this leaves.** A module loaded into the window is part of the
+measurement, and `-pa` is enough to make one so. `pyarms` prints `code:which/1`
+for `wasm_exec`, `wasm_instance` and `wasm_jit` on every arm for this reason.
+Counting instrumentation belongs outside the window or in its own arm, never
+inside the one being subtracted from.
+
+`allocwords:measure/3` is still what makes the isolation possible: it runs a
+setup in the measured process with tracing off, and opens the window only once
+the setup has returned. The first attempt at this experiment put the
+pre-lowering inside the measured fun, so both arms paid it and the difference
+came out at **4,176 words, 0.0%** -- a confident null produced by a window that
+was open too early.
 
 ### Where the run goes, so far
 
+Against the clean 28,145,449-word QuickJS request:
+
 | component | words | share | how it was separated |
 | --- | ---: | ---: | --- |
-| lowering | 20.6 M | 39% | pre-lowered outside the window |
-| dispatch, `#st{}` at 11 a time | 16.7 M | 32% | executed histogram times measured price |
-| retained IR, inside the 20.6 M above | 0.7 M | 2% | `erts_debug:size/1` |
-| instantiation | 0.14 M | 0.4% | staged measurement |
-| **accounted** | **37.3 M** | **~71%** | |
+| dispatch, `#st{}` at 11 a time | 16.7 M | 59% | executed histogram times measured price |
+| lowering, reached set | 0.76 M | 2.7% | pre-lowered outside the window |
+| instantiation | 0.13 M | 0.5% | `inwin` arm against `cold` |
+| **accounted** | **17.6 M** | **~62%** | |
 
-Against the plan's 80% bar this is not finished, and the remainder is not yet
-named. What it does settle is the ranking: lowering first, dispatch second, and
-both of them ahead of anything else that has been proposed.
+The correction reorders the ranking it used to support. **Dispatch is the
+dominant allocator and lowering is a rounding error next to it**, the reverse of
+what this file said before the instrument was taken out of the window. Against
+the plan's 80% bar the model is further from closing than the inflated version
+appeared to be, and the missing 38% is not yet named.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3835,3 +3835,75 @@ dominant allocator and lowering is a rounding error next to it**, the reverse of
 what this file said before the instrument was taken out of the window. Against
 the plan's 80% bar the model is further from closing than the inflated version
 appeared to be, and the missing 38% is not yet named.
+
+### CPython: lowering is 0.03% of the run, and the second request is free
+
+The same four arms on CPython 3.12, which is the workload the investigation
+started from. Every arm is its own emulator, the reply is asserted, and the
+walls are from the untraced repetition because the GC trace itself doubles them.
+
+| arm | allocated | clean wall |
+| --- | ---: | ---: |
+| cold, one request | 5,447,952,387 | 19,220 ms |
+| pre-lowered, all 11,448 functions lowered in the setup | 5,446,176,895 | 23,774 ms |
+| two requests to one instance | 5,446,975,427 | 18,963 ms |
+| instantiation inside the window | 5,455,801,206 | -- |
+
+Read as differences:
+
+| | words | share of the run |
+| --- | ---: | ---: |
+| lowering | 1,775,492 | **0.033%** |
+| instantiation | 7,848,819 | 0.14% |
+| second request | below zero, inside run-to-run noise | **~0%** |
+
+**Lowering every one of CPython's 11,448 functions takes 249 ms and 12,114,304
+words**, priced on its own in a window holding nothing else. That is 0.22% of a
+run. On the 25 MB guest the whole lazy-lowering design is worth a fifth of one
+per cent, and pre-lowering it makes the run *slower*: 23.8 s against 19.2 s,
+because the 6.8 M words of IR it retains enlarge the live set every major
+collection then has to walk.
+
+**The second request is free.** Two requests allocate what one does, to within
+run-to-run noise, and produce both replies. `_start` serves every line, so a
+prewarmed instance answers out of a Python interpreter that is already up.
+Nothing in the request path is worth optimising; all 5.45 G words are Python
+starting.
+
+That is the whole shape of the problem restated: for a `wasm32-wasi` command
+guest, essentially everything is start-up, and start-up is the interpreter
+executing the guest's own initialisation.
+
+### 383 million dispatches, and the model closes to 78%
+
+`call_count` tracing on `wasm_exec:run/3` counts one CPython request at
+**383,284,913 dispatches**. The instrument is a counter in the emulator and not
+a wrapper in the module, so unlike the sizing call it does not distort what it
+measures: the counted run allocated 5,454,869,254 words against the uncounted
+5,447,952,387, a difference of 0.13%.
+
+`trace_pattern/3` needs the module loaded first. On a module the emulator has
+not reached yet it matches nothing and answers 0, and `trace_info/2` then reads
+`undefined`, so the count comes back missing rather than failing.
+`bench/paths/tiered.erl` never hit this because it warms the workload before
+setting the pattern.
+
+At the measured 11 words an interpreted operation:
+
+| component | words | share |
+| --- | ---: | ---: |
+| dispatch, 383,284,913 at 11 | 4,216,134,043 | **77.4%** |
+| instantiation | 7,848,819 | 0.14% |
+| lowering | 1,775,492 | 0.03% |
+| **accounted** | **4,225,758,354** | **77.6%** |
+
+Against the plan's 80% bar that is close and not there. It is also a different
+answer from QuickJS, where the same model reaches 62%, and the gap between the
+two workloads is itself unexplained.
+
+What it settles is what to do next. Everything that is not the interpreter
+running the guest's instructions is under half a per cent: lowering, decoding,
+validating, instantiating and the request itself, all of them together, cannot
+pay for more than a rounding error of a CPython cold start. The only lever with
+the right order of magnitude is not executing those 383 million operations
+interpreted.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4276,3 +4276,36 @@ and then throws loses its final fuel value: only `leave/2` publishes, and
 `foreign_call/5` reads the callee's *committed* `#mut{}`, so an A -> B -> A
 recursion does not see A's in-flight state, and the exception branch drops
 mutations B made before throwing. Neither is visible to a depth test.
+
+### A heap fuse on the compiler cannot be had at a price worth paying
+
+The admission ceiling bounds how many functions a request may contain and says
+nothing about how big their bodies are, so an accepted request can still exhaust
+a node. The obvious cover is `max_heap_size` with `kill => true` on whatever runs
+`compile:forms/2`: an unanticipated guest then dies as one killed compiler, which
+this design already handles, instead of as a paging node.
+
+It does not work, and the measurement says why in one line. **`compile:forms/2`
+spawns a process of its own and runs everything in it.** A limit set on the
+process `wasm_jit` spawns bounds a process that only waits:
+
+| | compile | our process's heap | node RSS |
+| --- | ---: | ---: | ---: |
+| default, the compiler spawns | **167 s** | **0.34 GB** | 6.19 GB |
+| `no_spawn_compiler_process` | **293 s** | **4.16 GB** | 7.01 GB |
+
+QuickJS, one unit, `full`, same box at load 2.5 for both.
+
+The option exists for callers that already own worker processes, which we are,
+and with it the growth happens where a fuse can see it: 0.34 GB becomes 4.16 GB.
+It also costs **75% more compile time**, and the reason is the mechanism itself.
+`compile:forms/2`'s child never collects: it allocates its several gigabytes,
+returns the binary and exits, and a dying process frees its heap without a
+collection. Doing the work in a process that has to live through it means paying
+for those collections.
+
+So the choice is a fuse that sees nothing, or one that costs three quarters of
+the compile time again. **Neither ships.** The ceiling lands, and bounding what a
+compile may spend stays open with the reason recorded: it is not a matter of
+picking a number, it is that the memory is spent in a process nobody but the OTP
+compiler can pass flags to.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3597,3 +3597,59 @@ function boundary inside a running call rather than at a call boundary, or let
 `wasm_code_cache` carry a profile across runs so a second run adopts at its
 first call. The second is what the cache is already for and is the cheaper
 experiment.
+
+### A one-call guest can reach generated code, and keep it
+
+The section above found the tier unreachable for a `_start` guest, because
+`wasm_jit:maybe_adopt/3` adopts on a *later* call and such a guest has none.
+That is true of the call and false of the *instance*. `bench/paths/adopt.erl`
+runs one `_start`, watches `wasm_jit:counts/0` until the compiler lands, then
+runs a second instance of the same module. QuickJS, one JSON line in and out:
+
+| | cold cache | warm cache |
+| --- | ---: | ---: |
+| call 1, interpreted | 128 ms | 182 ms |
+| time until `compiled` | **150 s** | **1 s** |
+| call 2 | **28 ms** | **14 ms** |
+| counts after call 2 | `compiled 402, cached 0, entered 1` | `compiled 402, cached 1, entered 1` |
+
+The ask *is* raised by a one-call guest, 402 functions do get compiled, and a
+fresh instance adopts them at its first call. `entered => 1` is what says so;
+the wall time alone would not.
+
+**And the artifact persists**, which turns 150 seconds into 1. `cached => 1`
+is the proof it came off disk.
+
+### The fast layout and the cacheable one were only coupled by a default
+
+`wasm_code_cache:key/6` answers `undefined` for any identity that is not
+`{sha256, _}`, and `wasm:compile/1` leaves the identity unset, so nothing it
+compiles is ever kept. `wasm:load/1` hashes, and is also the path that puts the
+module in `persistent_term` -- which the sections above measured at **4.6x
+slower** on CPython, because the collector then sizes the heap for a live set
+the hot loop never reads.
+
+That reads like a trap with no way out: the only cacheable path is the slow one.
+It is not. `compile/2` already takes the identity, and its doc says why one
+would pass it. Passing the content hash gives both halves at once:
+
+```erlang
+wasm:compile(Bin, #{identity => {sha256, crypto:hash(sha256, Bin)}})
+```
+
+| | cold cache | warm cache |
+| --- | ---: | ---: |
+| time until `compiled` | 155 s | **0 s** |
+| call 2 | 18 ms | 16 ms, `cached => 1, entered => 1` |
+
+Module on the process heap, which is the layout that collects cheaply, and
+named by its content, which is what the cache needs. The five milliseconds of
+hashing that `compile/2`'s doc declines to spend by default buys a 150 second
+compile, once per machine rather than once per emulator.
+
+**Two harness bugs on the way here, both of which read as results.** A second
+call in the same process reused the stdin fun's "already sent" flag, so it hit
+end of file at once and returned in 19 ms with no reply: a 16x speedup that was
+a guest doing nothing, which is why the reply assertion is in the harness. And
+an earlier diagnosis that "the ask dies with the process" was wrong:
+`wasm:call/3` runs `after_call/2` at depth 0 before the caller moves on.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3483,3 +3483,44 @@ was built from is heap data or a literal.
 **Until it is, `load/1`'s doc oversells itself on a large module.** It is right
 about what it was written about, which is not paying to decode the same bytes
 twice; it is wrong if read as advice for the steady state.
+
+### The mechanism: the decoded module is ballast the collector sizes the heap from
+
+The section above left this open. It is not the module cache, the allocator or
+the binary vheap on their own. **The collector sizes a process's heap, and its
+binary vheap threshold, from that process's live set, and the decoded module is
+live data the hot loop never reads.** On the heap it is ballast that buys a
+large heap; off the heap the same churn collects into a small one.
+
+`garbage_collection` trace on the worker, one CPython start-up, medians over
+every collection:
+
+| | `compile/1` | `load/1` | `load/1` + `min_heap_size` |
+| --- | ---: | ---: | ---: |
+| collections | 1,057 | **17,648** | **344** |
+| `heap_size` | 5,048,040 | 311,549 | 18,062,236 |
+| `old_heap_size` | 24,834,443 | 1,360,290 | 1,310,226 |
+| `bin_vheap_block_size` | 3,387,320 | **46,422**, the default | 923,153 |
+
+Read the last two columns together. Under `load/1` the live set is 1.36 M words
+against 24.8 M, so every threshold the collector derives from it stays at or
+near its default, and the interpreter's 4.8 G words of churn cross that
+threshold 17,648 times instead of 1,057. Over half of those are fullsweeps.
+
+**`min_heap_size` gives the ballast back without the live set**: 344
+collections, fewer than `compile/1` manages, with an `old_heap_size` still at
+1.31 M. The floor is doing exactly what the module was doing by accident.
+
+What is not measured yet is the wall time of that third column, cleanly. Two of
+the measurements on the way to this table were wrong and are worth recording as
+traps, because both produced plausible numbers rather than obvious failures:
+
+- **A node-wide counter for a per-process question.** `erlang:statistics(
+  garbage_collection)` counts the whole node, and it reported no change from
+  `min_heap_size` while the worker's own collections fell 51x. Trace the
+  process.
+- **A stale `.beam`.** A three-way comparison returned byte-identical rows for
+  all three configurations, which is what a harness that never took the branch
+  looks like. Print something that proves the branch was taken: this one now
+  prints whether the module is a handle or inline, and the 22 MB peak heap says
+  so too.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3524,3 +3524,32 @@ traps, because both produced plausible numbers rather than obvious failures:
   looks like. Print something that proves the branch was taken: this one now
   prints whether the module is a handle or inline, and the 22 MB peak heap says
   so too.
+
+### The baseline, on an instrument that was proved first
+
+`bench/paths/allocwords.erl` derives one process's allocation from its own
+collection trace: `wordsize` summed over the end events between two forced
+majors, plus the change in live words. It is proved before use, against a list
+of N cons cells retained (which exercises the live-set half) and discarded
+(which exercises the reclaimed half), and agrees to 0.0% at N up to four
+million. `bench/paths/guestarm.erl` runs the pinned CPython through it.
+
+One start-up plus one request, worker positions reported separately because the
+first run in an emulator is not the second:
+
+| | `compile/1` w1 | `compile/1` w2 | `load/1` w1 | `load/1` w2 |
+| --- | ---: | ---: | ---: | ---: |
+| wall ms | 39,177 | 18,397 | 49,897 | 63,606 |
+| **allocated words** | 5,452,429,940 | 5,433,402,532 | 5,446,956,230 | 5,440,531,391 |
+| collections | 1,297 | 880 | 18,073 | 17,790 |
+| live at end | 23,777,394 | 23,777,394 | 342,430 | 342,430 |
+
+**Allocation is the same to within 0.1% across all four.** The live set differs
+by 69x and the collection count by 20x. That is the mechanism above, measured
+per process rather than inferred from a node-wide counter, and it is now the
+baseline any change is judged against.
+
+**The figure to beat is 5.45 G words, not 4.8 G.** The 4.8 G quoted earlier in
+this file came from `erlang:statistics(garbage_collection)`, which counts the
+node; it was about 12% low. Every allocation number here from now on comes from
+`allocwords`.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3553,3 +3553,47 @@ baseline any change is judged against.
 this file came from `erlang:statistics(garbage_collection)`, which counts the
 node; it was about 12% low. Every allocation number here from now on comes from
 `allocwords`.
+
+### CPython compiles completely, and the tier still never runs it
+
+Before attributing the 5.45 G words, the cheap question: can the compiled tier
+take this guest? `bench/paths/coverage.erl` on the pinned CPython:
+
+```
+functions                             11448
+compilable                            11447  100.0%
+over a generator bound                    1
+    too_many_locals                       1
+```
+
+**One refusal in 11,448**, and it is a generator bound rather than a missing
+instruction. `PERF.md` records QuickJS at 1.0x when 93% of its functions compile
+and 9.0x at 100%, so on coverage alone this is the best case there is.
+
+The tier still does nothing. With `compile => true, compile_after => 1`:
+
+| | wall w1 | wall w2 | `wasm_jit:counts/0` |
+| --- | ---: | ---: | --- |
+| tier off | 39,177 | 18,397 | not applicable |
+| tier on | 33,825 | 15,493 | `compiled => 0, entered => 0` |
+
+Nothing was compiled and nothing was entered, so the two rows differ by run
+position and noise, not by tiering.
+
+**The reason is the adoption point, and `wasm_jit:maybe_adopt/3` states it:**
+"what to compile is read from what this process has run and at the start of a
+call it has run nothing", so a call that finds nothing resident sets an ask and
+interprets, and the module is adopted *on a later call*.
+
+CPython does all of its work in **one** `_start` call. It asks when that call
+ends, and there is no later call. That is not special to CPython: it is the
+shape of every `wasm32-wasi` command-line program, which is most of what a
+toolchain emits. The tier is built for a workload of many calls into a resident
+instance, and a `_start` guest is a workload of one.
+
+So coverage is 100% and reachability is zero, for a reason that has nothing to
+do with instruction support. Two ways out, neither measured yet: adopt at a
+function boundary inside a running call rather than at a call boundary, or let
+`wasm_code_cache` carry a profile across runs so a second run adopts at its
+first call. The second is what the cache is already for and is the cheaper
+experiment.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3919,9 +3919,12 @@ runs, and **throws**:
 `wasm_core` pre-generates every atom a compiled unit can use, because nothing a
 guest supplies may become an atom. `?MAX_FUNS` is **2048**, and its comment says
 what it was sized against: "qjs has 1666 compilable functions". One CPython
-request reaches **2,333**. `fun_name/1` raises at the 2049th, part way through a
-compile that has already done its work, although `limits/0` exists so that "a
-caller can refuse before it starts rather than part way".
+request reaches **2,333**. `fun_name/1` raises at the 2049th, while `forms/8` is
+building the Core Erlang definitions (`wasm_core.erl:521`) and therefore before
+`compile:forms/2` is reached at all: the compiler worker is gone within 15
+seconds of what would have been a 464-second compile. It fails early, and
+`limits/0` exists so that "a caller can refuse before it starts rather than part
+way".
 
 What makes it invisible is what happens next. `compiler_loop/0` catches
 everything, gives the ask back and exits:
@@ -4016,6 +4019,98 @@ interpreted dispatch, and generated code does not allocate it.
 | wall | 53 ms to 16 ms | 19.2 s to 4.9 s |
 | functions compiled | 402 | 2,333 |
 | compile time, once | 165 s | 464 s |
+
+### Two shards against four
+
+`ceil(2333 / 2048)` is two, and two is what the automatic policy chooses. Four
+was measured first, by hand:
+
+| shards | clean wall | allocated | time to compiled | load during the arm |
+| ---: | ---: | ---: | ---: | ---: |
+| 2 | 4,813 ms | 259,856,472 | 637 s | 4.73 |
+| 4 | 4,851 ms | 305,591,745 | 464 s | 13.24 |
+
+**Two shards allocate 15% less and compile 37% slower.** A call between units
+goes through `wasm_exec:shard_call/8` and a call within one does not, so fewer
+units means fewer crossings; more units means more of `compile:forms/2` running
+at once. The policy optimises the run, because the compile is paid once per node
+and the run is paid per instance.
+
+### The fix, and what it measures
+
+Three changes, and only the first is the one anybody would have guessed.
+
+**The refusal was not a value.** `wasm_core:forms/8` already ended in
+
+```erlang
+catch
+    throw:{limit, _} = L -> {error, L};
+    throw:{unsupported, _} = U -> {error, U}
+```
+
+and nothing in `src/` ever threw `{limit, _}`: `fun_name/1` and `frame_name/1`
+raise with `erlang:error/1`, so that clause was dead and the refusal escaped.
+The class was wrong at the boundary, not in the helpers -- `wasm_core_SUITE`
+asserts `?assertError` on both and still does -- so the catch matches `error:`
+now.
+
+What that looked like on the commit before, on a synthetic module of 2,056
+eligible functions:
+
+| | parent | now |
+| --- | --- | --- |
+| `compile_sync`, first call | **raises `{limit, too_many_functions}` into `wasm:call/3`** | `{ok, [11]}` |
+| `counts()` after | all zeros | `compiled => 2056, entered => 1` |
+| asynchronous, same module | `compiled => 0`, silence | compiled, entered |
+
+The synchronous arm is the sharper half: a runtime whose rule is that nothing
+raises was raising a compiler's internal bound at the embedder, on a call the
+interpreter would have answered correctly.
+
+**`auto` never split.** `auto_shards/1` returned 1 whatever it was given, so the
+split that keeps a unit under `max_funs` happened only when a caller asked for
+it by hand. It is now `ceil(NFuns / max_funs)`, capped at `?MAX_SHARDS`, and 1
+for anything that fits -- so a guest that fitted before is bit-identical.
+
+**The bin packing balanced words, not functions.** `bins/2` took the lightest
+bin outright. One QuickJS function is 98,191 words, so a word-balanced split
+puts it alone and everything else in the bin beside it: a shard count computed
+against the bound and a packing free to ignore it is not a bound. It now takes
+the lightest bin *that can still take a function*, with the count carried in the
+bin so the choice stays one comparison.
+
+**The refusal is visible and paced.** `counts/0` gains `refused`, `failed` and
+`crashed`; `diagnostics/0` gives the reasons, normalised to a bounded shape and
+kept 64 deep in an ETS ring owned like every other tier table. A refusal leaves
+the ask standing rather than releasing it, so the retry interval paces it: on
+the parent commit `release_ask/1` set the timestamp to zero and the next hot
+call asked again at once, for ever, invisibly.
+
+**What it buys**, both guests through `bench/paths/pyarms.erl` with
+`compile_shards` left at `auto`, each arm its own emulator:
+
+| | QuickJS | CPython |
+| --- | ---: | ---: |
+| shards resident | **1** | **2** |
+| `entered` on the first `_start` | 1 | 1 |
+| allocated | 554,383 | 282,396,699 |
+| clean wall | 14 ms | **3,941 ms** |
+| interpreted, for comparison | 53 ms, 28.1 M words | 19,220 ms, 5.45 G words |
+| refused / failed / crashed | 0 / 0 / 0 | 0 / 0 / 0 |
+| compiled, once | 402 functions, 1 s from cache | 2,333 functions, 609 s |
+
+Against the thresholds fixed before the measurement: CPython at most 6,000 ms
+and 300 M words, two shards, QuickJS one shard. All met.
+
+**The regression gate is inconclusive on timing and clean on structure.**
+`realbench.erl` on QuickJS, eleven interleaved pairs across two runs in both
+orderings, minimum per half: the arms are indistinguishable, and the spread
+inside one arm (1,568 to 1,656 ms) is wider than the gap between them. Every
+half ran above the protocol's load-average gate of 8 -- this box sat between 9
+and 14 throughout -- so no speed claim is made in either direction. The
+structural argument is the one that carries: QuickJS reaches 402 functions,
+stays in one unit, and never enters `shard_call/8`, and the interpreter's own
+path is not touched by any of this.
 
 ### The disk cache saves 4% of a sharded compile
 

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3908,32 +3908,49 @@ pay for more than a rounding error of a CPython cold start. The only lever with
 the right order of magnitude is not executing those 383 million operations
 interpreted.
 
-### The ask does not survive the process that raised it
+### The compiled tier refuses CPython, silently, at function 2049
 
-A one-call guest asks for compilation when `_start` finishes. If the process
-that made that call then exits, **nothing is compiled**, and nothing reaches the
-on-disk cache either.
+CPython never runs compiled, and the reason is neither the `_start` shape nor
+the one function refused for `too_many_locals`. The compilation is attempted,
+runs, and **throws**:
 
-Three variants of the same QuickJS priming call, watched through
-`supervisor:count_children(wasm_jit_sup)` and a call trace on `wasm_jit:compile/4`
-and `wasm_instance:release_ask/1`:
+    wasm_jit:compile/4 threw {error, {limit, too_many_functions}}
 
-| priming call runs in | workers after 30 s | `compile/4` entered | compiled |
-| --- | ---: | --- | --- |
-| the process that stays alive | 1, still 1 at 105 s | yes | yes |
-| a spawned process kept alive | 1, still 1 at 105 s | yes | yes |
-| a spawned process that exits | **0** | **never** | **no** |
+`wasm_core` pre-generates every atom a compiled unit can use, because nothing a
+guest supplies may become an atom. `?MAX_FUNS` is **2048**, and its comment says
+what it was sized against: "qjs has 1666 compilable functions". One CPython
+request reaches **2,333**. `fun_name/1` raises at the 2049th, part way through a
+compile that has already done its work, although `limits/0` exists so that "a
+caller can refuse before it starts rather than part way".
 
-The worker is started -- `spawn_compile/2` gets its `{ok, Pid}` -- and then never
-receives its work, exiting on `compiler_loop/0`'s 30-second `after`. It is not a
-compile that failed: `compile/4` is never entered and `release_ask/1` is never
-called, so the ask is not given back either.
+What makes it invisible is what happens next. `compiler_loop/0` catches
+everything, gives the ask back and exits:
 
-This is exactly the shape of every `wasm32-wasi` command-line worker: one
-process, one `_start`, exit. Such a worker cannot warm anything, not even for
-the next process, which is why priming in `bench/paths/pyarms.erl` runs in the
-process that outlives it. Any prewarming design has to hold the asking process
-open until the compiler has the work.
+| | |
+| --- | --- |
+| logged | nothing |
+| `wasm_jit:counts()` | unchanged, all zeros |
+| next hot call | asks again, and the whole thing repeats |
+
+So a caller sees a compiled tier that is enabled, asks for compilation on every
+call, and never reports an error or a compilation. Only an exception trace on
+`compile/4` says why.
+
+**A correction, and the trap that caused it.** An earlier version of this
+section said the ask does not survive the process that raised it, on the
+evidence that a spawned priming process left `workers` at 0 while a surviving
+one kept a compiler running. That was wrong twice over. The trace patterns that
+were supposed to show `compile/4` being entered had matched **nothing**, because
+`erlang:trace_pattern/3` on a module the emulator has not loaded answers 0 and
+`trace_info/2` then reads `undefined` -- the same trap this file already records
+for the dispatch counter, hit a second time in the same session. And the
+difference between the arms was the watch, not the runtime: QuickJS takes 165
+seconds to compile, and the failing arm had been given 60. With the patterns
+actually set, the spawned arm enters `compile/4` and its compiler is still
+running at 45 seconds.
+
+Set the pattern, then check it returned 1. A trace that matches nothing looks
+exactly like a runtime that does nothing.
 
 ### A fresh instance that adopts before its first `_start` allocates 1.9% as much
 

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -3980,3 +3980,39 @@ asking. The 5.45 G words CPython allocates are the interpreter executing 383
 million operations, and generated code does not allocate them. Nothing else
 measured -- lowering, decoding, validation, instantiation, the request itself --
 is worth one per cent.
+
+### CPython compiled: 4.9 seconds instead of 19.2, and 94% of the allocation gone
+
+`compile_shards => 4` is enough to get CPython past `?MAX_FUNS`. The split is by
+size, so 2,333 functions become four units of a few hundred each and
+`fun_name/1` is never asked for a 2049th name. **This needs no change to the
+runtime**: it is an existing limit, and the default is one shard.
+
+Fresh instance, fresh process, generated code adopted before its first and only
+`_start`:
+
+| | cold, interpreted | adopted, four shards |
+| --- | ---: | ---: |
+| allocated | 5,447,952,387 | **305,591,745** |
+| collections | 1102 minor, 171 major | 47 minor, 24 major |
+| GC share of the traced wall | 59.3% | 37.3% |
+| clean wall | 19,220 ms | **4,851 ms** |
+| `entered` | 0 | **1** |
+
+**94.4% of the allocation is gone and the cold start is 4.0x faster**, on a box
+that was at load average 13 for the compiled arm and 9.9 for the interpreted
+one, so the wall is if anything pessimistic.
+
+Compiling the 2,333 reached functions took **464 seconds** and wrote a 19.8 MB
+`.beam`.
+
+Both guests now say the same thing, and it is the answer the whole
+investigation was after: an interpreted `wasm32-wasi` start-up is dominated by
+interpreted dispatch, and generated code does not allocate it.
+
+| | QuickJS | CPython |
+| --- | ---: | ---: |
+| allocation removed | 98.1% | 94.4% |
+| wall | 53 ms to 16 ms | 19.2 s to 4.9 s |
+| functions compiled | 402 | 2,333 |
+| compile time, once | 165 s | 464 s |

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4309,3 +4309,113 @@ the compile time again. **Neither ships.** The ceiling lands, and bounding what 
 compile may spend stays open with the reason recorded: it is not a matter of
 picking a number, it is that the memory is spent in a process nobody but the OTP
 compiler can pass flags to.
+
+### The two demo shapes: one the tier can see, one it cannot
+
+`wasm_demo` is the worked example, and running it against this branch answers
+two separate questions: whether the depth fix costs the interpreter anything,
+and what the tier is worth to the shape a worker runtime actually wants.
+`origin/main` (66bee0a) against the branch head (3aee434), interleaved in both
+orderings, load average 1.7 to 6.8 throughout.
+
+**The demo as written is unchanged, and it had to be.** One blocking `_start`
+per worker, requests through a mailbox, both pinned guests:
+
+| | before | after |
+| --- | ---: | ---: |
+| js, first request | 282-583 ms | 279-318 ms |
+| js, steady, 6 runs x 199 requests (min / med) | 1.175 / 11.36 ms | 1.153 / 11.39 ms |
+| py, first request | 32.58-33.46 s | 32.48-32.78 s |
+| py, steady, 3 runs x 29 requests (min / med) | 6.12 / 9.23 ms | 5.80 / 7.82 ms |
+
+The sign flips with ordering on every row. None of this branch is on that path:
+`do_call/4`'s new depth check is in the `#st{code = {Mod, Gen}}` clause and an
+uncompiled instance takes `#st{code = undefined}`; WASI imports are charged by
+`charge_host_call/1` and never reach `with_depth/2`; and the new
+`multiple_supertypes` check fires only on a declared supertype, which neither
+guest has. The demo's own four entry points answer identically on hex 0.2.0,
+`origin/main` and this branch.
+
+**And that shape cannot use the tier at all.** With
+`compile => true, compile_after => 1` on the instance, both arms answer
+`compiled => 0, entered => 0`. `after_call/2` asks at the *end* of an outermost
+invocation, because that is when `wasm_instance:executed/1` is full, and the
+demo's `_start` is one invocation that blocks in `fd_read` for the worker's
+whole life. No option changes it: the worker is structurally outside the tier,
+and the fix is a different shape rather than a different setting.
+
+**A fresh instance per request is the shape that reaches it.** Same module, one
+JSON line in and one out, `profile => script`:
+
+| QuickJS, `qjs-wasi.wasm` | before | after |
+| --- | ---: | ---: |
+| interpreted | 98 ms | 98 ms |
+| interpreted while the compile runs | ~147 ms | ~147 ms |
+| compiled, tail 200 (min / med, 3 pairs) | 57.58 / 60.12 ms | 57.86 / 60.30 ms |
+| functions compiled / entries | 410 / 459-471 | 410 / 461-469 |
+| the tier lands at request | 420-432 | 422-430 |
+
+Identical, which is the row that had to be checked: `check_depth(deeper(G0))` is
+on the compiled call path. The switchover costs nothing visible either. The peak
+across it is 159 to 176 ms, against a 98 ms floor and a 147 ms
+compile-in-progress rate.
+
+CPython is the same shape and a different order of magnitude. The compile is
+long enough that paying for it in 16-second requests wastes an hour, so it is
+timed directly through `wasm_jit:await/2` instead:
+
+| CPython 3.12, `python.wasm` | before | after |
+| --- | ---: | ---: |
+| interpreted, 3 pairs, both orderings (min / med) | 15.15-15.83 / 15.69-16.25 s | 15.53-15.73 / 15.69-15.81 s |
+| the request that asks | 28.4-43.1 s | 28.2-44.0 s |
+| compile, one unit, `baseline` | did not complete | **567 s** |
+| artifact | -- | 72.5 MB |
+| functions compiled | -- | 2,332 |
+| compiled, per request, n=6 (min / med / max) | -- | **6.19 / 6.22 / 6.51 s** |
+
+**2.5x, and it costs 567 seconds of a core to get.** The same trade QuickJS
+makes, an order of magnitude further along: a guest that spends 15.7 seconds
+interpreting spends 6.2 compiled, and 91 requests go by before the compile has
+paid for itself.
+
+**And the compiler is not free while it runs.** A CPython request measured 15.7
+seconds with nothing else happening and **67.5 seconds** with the compile in
+flight, at 198% CPU and 4.59 GB resident. On a node serving requests, the
+compile is not background in any sense the latency budget recognises.
+
+**The `before` compile did not complete, twice, and nothing on that arm says
+why.** Once it died after roughly an hour with the emulator back to 0.13 GB and
+no counter moved; once no compiler process appeared under `wasm_jit_sup` at all
+for a full hour of waiting. **No causal claim is made**: `before` ran first on
+both attempts, so ordering is confounded, and the runs were stopped rather than
+repeated in the other order. What the two attempts do show is the diagnostic
+gap. `counts/0` on the parent is `#{compiled, entered, cached}` and there is no
+`diagnostics/0`, so a compile that dies or is never spawned is indistinguishable
+from one still running. The `failed`, `crashed` and `refused` counters and the
+diagnostics ring this branch adds are exactly the instrument that was missing,
+and finding that out took two hours of watching `compiled => 0`.
+
+**`wasm:compile/1` cannot reach the on-disk cache, and nothing says so.** It
+gives the module a fresh `reference()` identity, and both `wasm_jit:key/1` and
+`wasm_code_cache:key/6` key on that identity, so `key/6` answers `undefined` and
+`artifact/8` never stores. Verified directly: 410 functions compiled, cache
+directory empty. Through `wasm:load/1`, which passes the content hash, the same
+run writes the artifact and the next start adopts it:
+
+| QuickJS, per request | ms |
+| --- | ---: |
+| interpreted, `wasm:load/1` | 151 |
+| compiled, `wasm:load/1`, cold | 17 |
+| compiled, `wasm:load/1`, warm cache (`cached => 1`) | **17** |
+
+Warm is the point rather than the number: it is 17 ms from the first request
+instead of from request 425, and the 63 seconds of a core are not paid again.
+Interpreted, `wasm:load/1` is *slower* than `wasm:compile/1` by half, 151
+against 98 ms and reproducible across three runs each. That is unexplained, is
+the same on both arms, and is the measurement to chase if the interpreted path
+of a cached module ever matters.
+
+**Found while measuring, and not fixed here.** `wasm_jit:await/2` is spec'd
+`-spec await(#inst{}, timeout())` and computes
+`erlang:monotonic_time(millisecond) + Timeout`, so the `infinity` its own spec
+admits is a `badarith`. Identical on `origin/main`; it predates this branch.

--- a/test/wasm_gc_SUITE.erl
+++ b/test/wasm_gc_SUITE.erl
@@ -19,6 +19,7 @@ all() ->
      identical_types_in_separate_groups_are_the_same,
      a_forward_reference_is_unknown,
      a_final_type_cannot_be_subtyped,
+     a_type_may_declare_only_one_supertype,
      a_mutable_field_is_invariant,
      packed_fields_round_trip_through_their_width,
      ref_eq_compares_identity_not_contents,
@@ -102,6 +103,15 @@ a_forward_reference_is_unknown(_Config) ->
 a_final_type_cannot_be_subtyped(_Config) ->
     ?assertMatch({error, #{class := invalid, kind := subtype_of_final}},
                  wasm:load(subtype_of_final())).
+
+%% The binary format encodes supertypes as a vector, so two of them decode
+%% cleanly; the specification bounds that vector at one. Validation used to walk
+%% whatever the vector held and check each entry on its own, which is coherent
+%% and is not the language. `type-subtyping.wast` asserts it as "multiple
+%% supertypes", and this says the same thing without needing that checkout.
+a_type_may_declare_only_one_supertype(_Config) ->
+    ?assertMatch({error, #{class := invalid, kind := multiple_supertypes}},
+                 wasm:load(two_supertypes())).
 
 %% A mutable field is written through as well as read, so narrowing it in a
 %% subtype would let a write through the supertype store a value the subtype's
@@ -191,6 +201,18 @@ subtype_of_final() ->
                             [16#5F, wasm_asm:uleb(0)],          % final struct
                             [16#50, wasm_asm:uleb(1), wasm_asm:uleb(0),
                              16#5F, wasm_asm:uleb(0)]])]).      % sub of it
+
+%% Two open parents and a child naming both: valid to decode, invalid to accept.
+two_supertypes() ->
+    wasm_asm:module(
+      [wasm_asm:section(1, [wasm_asm:uleb(3),
+                            [16#50, wasm_asm:uleb(0),
+                             16#5F, wasm_asm:uleb(0)],          % open struct
+                            [16#50, wasm_asm:uleb(0),
+                             16#5F, wasm_asm:uleb(0)],          % open struct
+                            [16#50, wasm_asm:uleb(2),
+                             wasm_asm:uleb(0), wasm_asm:uleb(1),
+                             16#5F, wasm_asm:uleb(0)]])]).      % sub of both
 
 %% A supertype with one mutable anyref field, and a subtype narrowing it.
 narrowed_mutable_field() -> narrowed_field(1).

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -1,0 +1,319 @@
+%% @doc What the compiled tier does with a module it cannot fit in one unit.
+%%
+%% `wasm_core` draws every name a compiled unit can use from a pool it generates
+%% at startup, because nothing a guest supplies may become an atom. The pool is
+%% `max_funs` deep, and a unit past it is refused.
+%%
+%% Three things about that refusal were wrong at once, and CPython found all
+%% three: the split that would keep each unit under the bound never happened,
+%% the bin packing balanced words without regard to the bound, and the refusal
+%% left `wasm_core:forms/8` as an exception rather than a value, so
+%% `wasm_jit:compiler_loop/0` swallowed it and the tier declined a 25 MB guest
+%% silently, for ever, while asking again every retry interval.
+%%
+%% Every case here that reproduces one of those fails on the commit before it,
+%% which is noted case by case. The ones that only guard a behaviour say so.
+-module(wasm_jit_bounds_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("wasm/include/wasm.hrl").
+
+all() ->
+    [{group, running}, {group, without_the_table}].
+
+groups() ->
+    [{running, [],
+      [more_functions_than_one_unit_holds_still_compiles,
+       an_uneven_split_still_respects_the_function_bound,
+       a_module_past_every_shard_is_refused_and_says_so,
+       a_unit_over_the_bound_is_a_value_not_an_exception,
+       a_refusal_is_paced_by_the_retry_interval,
+       a_forced_refusal_is_counted_once,
+       the_shard_policy_splits_only_what_does_not_fit,
+       a_module_under_the_bound_is_still_one_unit,
+       the_ring_keeps_only_the_newest,
+       the_ring_normalises_what_it_is_given,
+       normalising_never_builds_the_representation]},
+     %% Its own group because it stops the application, which takes the store
+     %% and its tables with it. A test process cannot delete them: they are
+     %% bequeathed to `wasm_store_sup`.
+     {without_the_table, [],
+      [every_diagnostic_api_tolerates_the_absent_table]}].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    Config.
+
+end_per_suite(_) -> ok.
+
+init_per_group(running, Config) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    Config;
+init_per_group(without_the_table, Config) ->
+    ok = application:stop(wasm),
+    Config.
+
+end_per_group(running, _) -> ok;
+end_per_group(without_the_table, _) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    ok.
+
+init_per_testcase(_, Config) ->
+    wasm_jit:reset_counts(),
+    Config.
+
+end_per_testcase(_, _) ->
+    wasm_jit:reset_counts(),
+    ok.
+
+%%% ---------------------------------------------------------------- cases ---
+
+%% Reproduces the defect. On the parent commit `{limit, too_many_functions}`
+%% escapes as an exception, the compiler swallows it, and every counter stays
+%% at zero while the module answers interpreted for ever.
+more_functions_than_one_unit_holds_still_compiles(_) ->
+    N = max_funs() + 8,
+    M = build(many_wat(N)),
+    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    %% The second call is the one that can enter: the first asks when it ends.
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    #{entered := E, compiled := C, refused := R} = wasm_jit:counts(),
+    ?assertEqual(0, R, "a module that fits in two units was refused"),
+    ?assert(C >= N, "not every eligible function was compiled"),
+    ?assert(E > 0, "generated code was never entered, so this case compared "
+                   "the interpreter with itself"),
+    ?assertEqual(2, wasm_jit:shards(I)),
+    ok = wasm:destroy(I).
+
+%% The adversarial split. One function is orders of magnitude larger in IR than
+%% the rest, so a bin packer balancing words alone puts every small function in
+%% the other bin and blows the bound there. Fails on the parent commit and on
+%% the shard policy alone; passes only once the packing counts functions too.
+an_uneven_split_still_respects_the_function_bound(_) ->
+    Small = max_funs() + 8,
+    M = build(lopsided_wat(Small, 2000)),
+    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    #{refused := R, failed := F} = wasm_jit:counts(),
+    ?assertEqual({0, 0}, {R, F},
+                 "a word-balanced split overfilled one unit"),
+    ?assertEqual([], wasm_jit:diagnostics()),
+    ok = wasm:destroy(I).
+
+%% Past every shard there is no split that fits, and the answer is a refusal
+%% that says so rather than silence. Reproduces the invisibility.
+a_module_past_every_shard_is_refused_and_says_so(_) ->
+    N = 4 * max_funs() + 4,
+    M = build(many_wat(N)),
+    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    %% Still answers, because interpreting is always correct.
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    #{refused := R, entered := E, crashed := Cr} = wasm_jit:counts(),
+    ?assertEqual(1, R),
+    ?assertEqual(0, Cr, "a refusal was counted as a crash"),
+    ?assertEqual(0, E),
+    ?assertMatch([{refused, _, {limit, {too_many_functions, N}}}],
+                 wasm_jit:diagnostics()),
+    ok = wasm:destroy(I).
+
+%% The root defect, at the boundary where it lived: a unit over the bound must
+%% come back from the generator as a value. Forced to one shard so the deep
+%% refusal in `wasm_core:fun_name/1` is what answers, not the cheap pre-check.
+%%
+%% `wasm_core_SUITE` asserts `?assertError` on `fun_name/1` and `frame_name/1`
+%% and still passes: the helpers keep their contract, the boundary caught the
+%% wrong class.
+a_unit_over_the_bound_is_a_value_not_an_exception(_) ->
+    M = build(many_wat(max_funs() + 8)),
+    {ok, I} = wasm:instantiate(M, #{}, (sync(whole()))#{compile_shards => 1}),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    #{refused := R, crashed := Cr} = wasm_jit:counts(),
+    ?assertEqual({1, 0}, {R, Cr}),
+    ?assertMatch([{refused, _, {limit, too_many_functions}}],
+                 wasm_jit:diagnostics()),
+    ok = wasm:destroy(I).
+
+%% A refusal leaves the ask standing so the retry interval paces it. Releasing
+%% it would set the timestamp to zero and the next call would ask again at
+%% once, which is what the parent commit does, invisibly.
+a_refusal_is_paced_by_the_retry_interval(_) ->
+    Was = application:get_env(wasm, compile_retry_seconds),
+    ok = application:set_env(wasm, compile_retry_seconds, 1),
+    try
+        M = build(called_wat(4 * max_funs() + 4)),
+        {ok, I} = wasm:instantiate(M, #{}, whole()),
+        [?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])) || _ <- lists:seq(1, 5)],
+        ?assertEqual(ok, until(fun() -> refused() >= 1 end, 5000)),
+        %% Five calls inside one interval, one refusal.
+        ?assertEqual(1, refused()),
+        timer:sleep(1500),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ?assertEqual(ok, until(fun() -> refused() >= 2 end, 5000),
+                     "the interval expired and nothing asked again"),
+        ok = wasm:destroy(I)
+    after
+        case Was of
+            undefined -> application:unset_env(wasm, compile_retry_seconds);
+            {ok, V} -> application:set_env(wasm, compile_retry_seconds, V)
+        end
+    end.
+
+%% `compile_force` raises deliberately. That raise happens after the outcome is
+%% recorded and outside the compiler's `try`, so it is one record and not a
+%% refusal plus a crash. Fails on the parent commit, where the raise is inside
+%% `build/7` and lands in the catch.
+a_forced_refusal_is_counted_once(_) ->
+    M = build(called_wat(4 * max_funs() + 4)),
+    {ok, I} = wasm:instantiate(M, #{}, (whole())#{compile_force => true}),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    ?assertEqual(ok, until(fun() -> refused() >= 1 end, 5000)),
+    timer:sleep(200),
+    #{refused := R, crashed := Cr} = wasm_jit:counts(),
+    ?assertEqual({1, 0}, {R, Cr}),
+    ok = wasm:destroy(I).
+
+%% A guard on the policy, not a reproduction: pure, and asserted directly.
+the_shard_policy_splits_only_what_does_not_fit(_) ->
+    Max = max_funs(),
+    ?assertEqual(1, wasm_jit:shard_count(1, #{})),
+    ?assertEqual(1, wasm_jit:shard_count(Max, #{})),
+    ?assertEqual(2, wasm_jit:shard_count(Max + 1, #{})),
+    ?assertEqual(2, wasm_jit:shard_count(2 * Max, #{})),
+    ?assertEqual(3, wasm_jit:shard_count(2 * Max + 1, #{})),
+    %% Capped, and past the cap is what `generate_1/5` refuses.
+    ?assertEqual(4, wasm_jit:shard_count(400 * Max, #{})),
+    %% An explicit request still wins, and is the number of bins *asked* for:
+    %% empty ones are dropped, so one function in four bins is one part.
+    ?assertEqual(4, wasm_jit:shard_count(1, #{compile_shards => 4})),
+    ?assertEqual(4, wasm_jit:shard_count(1, #{compile_shards => 99})).
+
+%% A guard: a guest that fits in one unit must still be one unit, because a
+%% split turns a call between functions into a crossing.
+a_module_under_the_bound_is_still_one_unit(_) ->
+    M = build(many_wat(16)),
+    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    ?assertEqual(1, wasm_jit:shards(I)),
+    ok = wasm:destroy(I).
+
+the_ring_keeps_only_the_newest(_) ->
+    ok = wasm_code_slots:clear_diagnostics(),
+    [ok = wasm_code_slots:record_diagnostic(Seq, refused, {k, Seq},
+                                            {limit, Seq})
+     || Seq <- lists:seq(1, 200)],
+    D = wasm_code_slots:diagnostics(),
+    ?assertEqual(64, length(D)),
+    %% Oldest first, and the oldest kept is the 137th of 200.
+    ?assertEqual([{refused, {k, S}, {limit, S}} || S <- lists:seq(137, 200)], D),
+    ok = wasm_code_slots:clear_diagnostics(),
+    ?assertEqual([], wasm_code_slots:diagnostics()).
+
+the_ring_normalises_what_it_is_given(_) ->
+    ok = wasm_code_slots:clear_diagnostics(),
+    M = build(many_wat(4 * max_funs() + 4)),
+    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    {ok, _} = wasm:call(I, ~"f", [10]),
+    [{refused, _, Reason}] = wasm_jit:diagnostics(),
+    %% Small, and measured with `flat_size/1`. Not `erts_debug:size/1`, which
+    %% allocates 172 words for every word it walks and has already produced one
+    %% false finding in this project's measurement record.
+    ?assert(erts_debug:flat_size(Reason) < 32),
+    ok = wasm:destroy(I).
+
+%% Checking the stored row cannot see a huge transient. This runs the
+%% normalisation under a heap ceiling: a formatting implementation builds the
+%% whole representation and is killed, a structural one allocates nothing.
+normalising_never_builds_the_representation(_) ->
+    Huge = lists:duplicate(1000000, $x),
+    {P, _Ref} = spawn_opt(
+                  fun() ->
+                      ok = wasm_code_slots:record_diagnostic(
+                             1, failed, k,
+                             wasm_jit:normalize_reason({odd, Huge})),
+                      exit(done)
+                  end,
+                  [monitor, {max_heap_size, #{size => 200000, kill => true,
+                                              error_logger => false}}]),
+    ?assertEqual(done, wait_exit(P)).
+
+every_diagnostic_api_tolerates_the_absent_table(_) ->
+    ?assertEqual(undefined, ets:whereis(wasm_code_diag)),
+    ?assertEqual([], wasm_code_slots:diagnostics()),
+    ?assertEqual(ok, wasm_code_slots:clear_diagnostics()),
+    ?assertEqual(ok, wasm_code_slots:record_diagnostic(1, refused, k, r)),
+    ?assertEqual([], wasm_code_slots:diagnostics()).
+
+%%% -------------------------------------------------------------- helpers ---
+
+max_funs() -> map_get(max_funs, wasm_core:limits()).
+
+whole() -> #{compile => true, compile_after => 1, compile_whole => true}.
+
+sync(Opts) -> Opts#{compile_sync => true}.
+
+refused() -> map_get(refused, wasm_jit:counts()).
+
+%% `f` plus N-1 more, none of them exported, all of them eligible. Every one is
+%% compiled because `compile_whole` asks for what exists rather than what ran.
+%%
+%% Synchronous compilation only. `wasm_jit:spawn_compile/2` reads
+%% `wasm_instance:executed/1` directly rather than going through `wanted/2`, so
+%% the asynchronous path compiles what ran whatever `compile_whole` says. The
+%% cases that need a large unit off the calling process use `called_wat/1`.
+many_wat(N) ->
+    iolist_to_binary(
+      ["(module (func (export \"f\") (param i32) (result i32)
+          local.get 0 i32.const 1 i32.add)",
+       [["(func (param i32) (result i32) local.get 0 i32.const ",
+         integer_to_list(I rem 100), " i32.add)"] || I <- lists:seq(2, N)],
+       ")"]).
+
+%% Many tiny functions and one enormous one, so the IR words are lopsided and
+%% the packing has to keep counting functions rather than only weighing them.
+lopsided_wat(Small, Big) ->
+    iolist_to_binary(
+      ["(module (func (export \"f\") (param i32) (result i32)
+          local.get 0 i32.const 1 i32.add)",
+       [["(func (param i32) (result i32) local.get 0 i32.const ",
+         integer_to_list(I rem 100), " i32.add)"] || I <- lists:seq(2, Small)],
+       "(func (param i32) (result i32) local.get 0",
+       [" i32.const 1 i32.add" || _ <- lists:seq(1, Big)],
+       ")",
+       ")"]).
+
+%% As `many_wat/1`, and `f` calls every one of them, so they are all *executed*
+%% and the asynchronous path -- which compiles what ran and not what exists --
+%% sees the whole module.
+called_wat(N) ->
+    iolist_to_binary(
+      ["(module (func (export \"f\") (param i32) (result i32)",
+       [[" i32.const 0 call ", integer_to_list(I), " drop"]
+        || I <- lists:seq(1, N - 1)],
+       " local.get 0 i32.const 1 i32.add)",
+       [["(func (param i32) (result i32) local.get 0 i32.const ",
+         integer_to_list(I rem 100), " i32.add)"] || I <- lists:seq(2, N)],
+       ")"]).
+
+build(Wat) ->
+    {ok, P} = wasm_wat:module(Wat),
+    {ok, M} = wasm_validate:module(P),
+    M.
+
+until(F, Ms) -> until(F, Ms, erlang:monotonic_time(millisecond) + Ms).
+
+until(F, Ms, Deadline) ->
+    case F() of
+        true -> ok;
+        false ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                false -> timeout;
+                true -> timer:sleep(20), until(F, Ms, Deadline)
+            end
+    end.
+
+wait_exit(P) ->
+    receive {'DOWN', _, process, P, R} -> R after 30000 -> timeout end.

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -27,6 +27,9 @@
 %% case, which nothing derived from `max_funs()` can do.
 -define(CPYTHON_HOT_FUNS, 2333).
 -define(CPYTHON_WHOLE_FUNS, 11447).
+%% `?MAX_SHARDS` is private to `wasm_jit`; this is the same number, asserted
+%% against `compile_limits/0` so a change there fails here rather than silently.
+-define(MAX_SHARDS_HERE, 4).
 
 all() ->
     [{group, running}, {group, without_the_table}].
@@ -42,6 +45,7 @@ groups() ->
        the_shard_policy_splits_only_what_does_not_fit,
        a_cpython_sized_hot_set_is_one_real_unit,
        the_pool_covers_the_measured_cpython_sets,
+       a_request_past_the_ceiling_is_refused_before_it_is_lowered,
        compile_whole_reaches_the_background_compiler,
        eight_callers_share_one_background_compile,
        a_compile_outlives_the_process_that_asked_for_it,
@@ -230,12 +234,26 @@ a_cpython_sized_hot_set_is_one_real_unit(_) ->
 %% the value CPython does not fit.
 the_pool_covers_the_measured_cpython_sets(_) ->
     Max = max_funs(),
+    Ceiling = map_get(max_compile_funs, wasm_jit:compile_limits()),
     ?assert(Max >= ?CPYTHON_HOT_FUNS,
             "one _start's worth of CPython no longer fits a single unit, so its "
             "artifact is no longer cacheable"),
     ?assertEqual(1, wasm_jit:shard_count(?CPYTHON_HOT_FUNS, #{})),
     ?assertEqual(3, wasm_jit:shard_count(?CPYTHON_WHOLE_FUNS, #{})),
-    ?assert(?CPYTHON_WHOLE_FUNS =< 4 * Max).
+    %% The hot set is admitted; the whole module is **not**, and that is the
+    %% point of the two bounds being separate. The name pool genuinely covers
+    %% 11,447 names across three units -- it would compile, given the memory --
+    %% and admission rejects it anyway, because a request that size was measured
+    %% at 33 GB resident and published nothing.
+    ?assert(?CPYTHON_HOT_FUNS =< Ceiling),
+    ?assert(?CPYTHON_WHOLE_FUNS > Ceiling,
+            "the acceptance ceiling admits the whole-module compile again"),
+    ?assert(?CPYTHON_WHOLE_FUNS =< ?MAX_SHARDS_HERE * Max,
+            "the name pool no longer covers what admission is refusing, so the "
+            "refusal would happen for the wrong reason"),
+    %% And the ceiling itself: exactly at it is admitted, one past it is not.
+    ?assertEqual(1, wasm_jit:shard_count(1, #{})),
+    ?assert(Ceiling > Max, "the ceiling is not distinct from the name pool").
 
 %% `compile_whole` has to mean the same thing off the calling process.
 %%
@@ -271,6 +289,58 @@ compile_whole_reaches_the_background_compiler(_) ->
         %% lease behind for the next one to trip over.
         ok = wasm:destroy(I)
     end.
+
+%% Admission counts what was *asked for*, before anything is lowered.
+%%
+%% `unit/2` lowers every selected function and only then filters by
+%% `can_compile/2`, so counting its output meant a refused request had already
+%% built and retained its whole IR -- 3.7 M words for CPython. It also meant a
+%% module of many unsupported functions could lower an arbitrary number of them
+%% while never reaching the ceiling in *eligible* ones, which is what this
+%% module is: 8,193 functions the generator refuses.
+%%
+%% On the parent that costs 8,193 lowerings and answers `retry`, because
+%% `can_compile/2` rejects them all, `unit/2` returns `[]` and an empty unit is
+%% a retry rather than a refusal. Here it costs none and answers `refused`.
+%% Unsupported on purpose, so the parent-failure run cannot accidentally start
+%% an enormous compilation.
+a_request_past_the_ceiling_is_refused_before_it_is_lowered(_) ->
+    N = map_get(max_compile_funs, wasm_jit:compile_limits()) + 1,
+    M = build(unsupported_wat(N)),
+    {module, _} = code:ensure_loaded(wasm_instance),
+    1 = erlang:trace_pattern({wasm_instance, compiler_ir, 2}, true,
+                             [call_count]),
+    try
+        {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+        try
+            %% Still answers, because a refusal means interpret.
+            ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+            ?assertEqual(1, refused()),
+            ?assertMatch([{refused, _, {limit, {too_many_functions, N}}}],
+                         wasm_jit:diagnostics()),
+            {call_count, Lowered} =
+                erlang:trace_info({wasm_instance, compiler_ir, 2}, call_count),
+            ?assertEqual(0, Lowered,
+                         "a refused request lowered its functions anyway")
+        after
+            ok = wasm:destroy(I)
+        end
+    after
+        _ = erlang:trace_pattern({wasm_instance, compiler_ir, 2}, false,
+                                 [call_count])
+    end.
+
+%% `f` compiles; every other function reads an exported mutable global, which
+%% becomes a reference cell and is refused with `global_get_ref`.
+unsupported_wat(N) ->
+    iolist_to_binary(
+      ["(module (global $g (export \"g\") (mut i32) (i32.const 0))
+         (func (export \"f\") (param i32) (result i32)
+           local.get 0 i32.const 1 i32.add)",
+       [["(func (param i32) (result i32) global.get $g drop local.get 0"
+         " i32.const ", integer_to_list(I rem 100), " i32.add)"]
+        || I <- lists:seq(2, N)],
+       ")"]).
 
 %% One background compile, eight callers, and every observation a delta.
 %%

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -34,6 +34,7 @@ groups() ->
        a_forced_refusal_is_counted_once,
        the_shard_policy_splits_only_what_does_not_fit,
        a_module_under_the_bound_is_still_one_unit,
+       compile_whole_reaches_the_background_compiler,
        the_ring_keeps_only_the_newest,
        the_ring_normalises_what_it_is_given,
        normalising_never_builds_the_representation]},
@@ -200,6 +201,41 @@ a_module_under_the_bound_is_still_one_unit(_) ->
     ?assertEqual(1, wasm_jit:shards(I)),
     ok = wasm:destroy(I).
 
+%% `compile_whole` has to mean the same thing off the calling process.
+%%
+%% `spawn_compile/2` read `wasm_instance:executed/1` directly rather than going
+%% through `wanted/2`, so the background compiler compiled what had run and the
+%% option was honoured only under `compile_sync`.
+%%
+%% 257 functions and not fewer. At or below `?LAZY_THRESHOLD` a module is lowered
+%% eagerly, `executed/1` answers `[]`, and `[]` already means every function --
+%% so a smaller module passes this whether the bug is there or not.
+compile_whole_reaches_the_background_compiler(_) ->
+    N = 257,
+    M = build(many_wat(N)),
+    {ok, I} = wasm:instantiate(M, #{}, whole()),
+    try
+        %% One function called, every function wanted.
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        %% On the instance rather than on the global counter: `await/2` answers
+        %% as soon as *this* instance has adopted a slot, so a broken
+        %% implementation comes back having compiled the one function that ran
+        %% and the count below fails at once, instead of a poll timing out
+        %% thirty seconds later and saying only that something did not happen.
+        ?assertEqual(ok, wasm_jit:await(I, 30000)),
+        #{compiled := C, refused := R, failed := F, crashed := Cr} =
+            wasm_jit:counts(),
+        ?assertEqual(N, C),
+        ?assertEqual({0, 0, 0}, {R, F, Cr}),
+        ?assertEqual(1, wasm_jit:shards(I)),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ?assert(map_get(entered, wasm_jit:counts()) > 0)
+    after
+        %% A failing asynchronous case must not leave an instance or a slot
+        %% lease behind for the next one to trip over.
+        ok = wasm:destroy(I)
+    end.
+
 the_ring_keeps_only_the_newest(_) ->
     ok = wasm_code_slots:clear_diagnostics(),
     [ok = wasm_code_slots:record_diagnostic(Seq, refused, {k, Seq},
@@ -256,6 +292,8 @@ whole() -> #{compile => true, compile_after => 1, compile_whole => true}.
 sync(Opts) -> Opts#{compile_sync => true}.
 
 refused() -> map_get(refused, wasm_jit:counts()).
+
+compiled() -> map_get(compiled, wasm_jit:counts()).
 
 %% `f` plus N-1 more, none of them exported, all of them eligible. Every one is
 %% compiled because `compile_whole` asks for what exists rather than what ran.

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -21,6 +21,13 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("wasm/include/wasm.hrl").
 
+%% Measured, on the pinned guest recorded in `test/audit/PERF.md`: CPython 3.12
+%% reaches this many functions in one `_start`, and has this many eligible in
+%% the whole module. They are here so that putting the pool back to 2048 fails a
+%% case, which nothing derived from `max_funs()` can do.
+-define(CPYTHON_HOT_FUNS, 2333).
+-define(CPYTHON_WHOLE_FUNS, 11447).
+
 all() ->
     [{group, running}, {group, without_the_table}].
 
@@ -33,8 +40,11 @@ groups() ->
        a_refusal_is_paced_by_the_retry_interval,
        a_forced_refusal_is_counted_once,
        the_shard_policy_splits_only_what_does_not_fit,
-       a_module_under_the_bound_is_still_one_unit,
+       a_cpython_sized_hot_set_is_one_real_unit,
+       the_pool_covers_the_measured_cpython_sets,
        compile_whole_reaches_the_background_compiler,
+       eight_callers_share_one_background_compile,
+       a_compile_outlives_the_process_that_asked_for_it,
        the_ring_keeps_only_the_newest,
        the_ring_normalises_what_it_is_given,
        normalising_never_builds_the_representation]},
@@ -108,7 +118,7 @@ an_uneven_split_still_respects_the_function_bound(_) ->
 %% Past every shard there is no split that fits, and the answer is a refusal
 %% that says so rather than silence. Reproduces the invisibility.
 a_module_past_every_shard_is_refused_and_says_so(_) ->
-    N = 4 * max_funs() + 4,
+    N = 4 * max_funs() + 1,
     M = build(many_wat(N)),
     {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
     %% Still answers, because interpreting is always correct.
@@ -129,7 +139,7 @@ a_module_past_every_shard_is_refused_and_says_so(_) ->
 %% and still passes: the helpers keep their contract, the boundary caught the
 %% wrong class.
 a_unit_over_the_bound_is_a_value_not_an_exception(_) ->
-    M = build(many_wat(max_funs() + 8)),
+    M = build(many_wat(max_funs() + 1)),
     {ok, I} = wasm:instantiate(M, #{}, (sync(whole()))#{compile_shards => 1}),
     ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
     #{refused := R, crashed := Cr} = wasm_jit:counts(),
@@ -145,8 +155,10 @@ a_refusal_is_paced_by_the_retry_interval(_) ->
     Was = application:get_env(wasm, compile_retry_seconds),
     ok = application:set_env(wasm, compile_retry_seconds, 1),
     try
-        M = build(called_wat(4 * max_funs() + 4)),
-        {ok, I} = wasm:instantiate(M, #{}, whole()),
+        %% One unit over its own bound, not four over theirs: the ceiling case
+        %% below is the expensive one and there is no reason for two.
+        M = build(many_wat(max_funs() + 1)),
+        {ok, I} = wasm:instantiate(M, #{}, (whole())#{compile_shards => 1}),
         [?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])) || _ <- lists:seq(1, 5)],
         ?assertEqual(ok, until(fun() -> refused() >= 1 end, 5000)),
         %% Five calls inside one interval, one refusal.
@@ -168,8 +180,9 @@ a_refusal_is_paced_by_the_retry_interval(_) ->
 %% refusal plus a crash. Fails on the parent commit, where the raise is inside
 %% `build/7` and lands in the catch.
 a_forced_refusal_is_counted_once(_) ->
-    M = build(called_wat(4 * max_funs() + 4)),
-    {ok, I} = wasm:instantiate(M, #{}, (whole())#{compile_force => true}),
+    M = build(many_wat(max_funs() + 1)),
+    {ok, I} = wasm:instantiate(M, #{}, (whole())#{compile_force => true,
+                                                  compile_shards => 1}),
     ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
     ?assertEqual(ok, until(fun() -> refused() >= 1 end, 5000)),
     timer:sleep(200),
@@ -194,12 +207,35 @@ the_shard_policy_splits_only_what_does_not_fit(_) ->
 
 %% A guard: a guest that fits in one unit must still be one unit, because a
 %% split turns a call between functions into a crossing.
-a_module_under_the_bound_is_still_one_unit(_) ->
-    M = build(many_wat(16)),
+%% A guard, not a reproduction: it passes on the parent commit by construction.
+%% What it adds over `shard_count/2` is that the OTP compiler actually accepts a
+%% generated module of this size, which no pure assertion can say. Sized at
+%% CPython's measured hot set, because that is the module this bound exists for.
+a_cpython_sized_hot_set_is_one_real_unit(_) ->
+    N = ?CPYTHON_HOT_FUNS,
+    M = build(many_wat(N)),
     {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
-    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
-    ?assertEqual(1, wasm_jit:shards(I)),
-    ok = wasm:destroy(I).
+    try
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ?assertEqual(1, wasm_jit:shards(I)),
+        ?assertEqual(N, compiled()),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ?assert(map_get(entered, wasm_jit:counts()) > 0)
+    after
+        ok = wasm:destroy(I)
+    end.
+
+%% The requirement, as opposed to the algorithm. Everything else in this suite
+%% is written against `max_funs()` and would pass just as well at 2048, which is
+%% the value CPython does not fit.
+the_pool_covers_the_measured_cpython_sets(_) ->
+    Max = max_funs(),
+    ?assert(Max >= ?CPYTHON_HOT_FUNS,
+            "one _start's worth of CPython no longer fits a single unit, so its "
+            "artifact is no longer cacheable"),
+    ?assertEqual(1, wasm_jit:shard_count(?CPYTHON_HOT_FUNS, #{})),
+    ?assertEqual(3, wasm_jit:shard_count(?CPYTHON_WHOLE_FUNS, #{})),
+    ?assert(?CPYTHON_WHOLE_FUNS =< 4 * Max).
 
 %% `compile_whole` has to mean the same thing off the calling process.
 %%
@@ -236,6 +272,100 @@ compile_whole_reaches_the_background_compiler(_) ->
         ok = wasm:destroy(I)
     end.
 
+%% One background compile, eight callers, and every observation a delta.
+%%
+%% The `entered` assertion is the point of the second barrier: eight second
+%% calls must give exactly eight entries. A merely positive delta would pass
+%% with one caller in generated code and seven still interpreting.
+eight_callers_share_one_background_compile(_) ->
+    ?assertEqual(ok, until(fun() -> workers() =:= 0 end, 10000)),
+    wasm_jit:reset_counts(),
+    N = 257,
+    M = build(many_wat(N)),
+    {ok, I} = wasm:instantiate(M, #{}, whole()),
+    try
+        Ps = [caller(I) || _ <- lists:seq(1, 8)],
+        ?assertEqual(lists:duplicate(8, {ok, [11]}), release(Ps)),
+        ?assertEqual(ok, wasm_jit:await(I, 60000)),
+        #{compiled := C, refused := R, failed := F, crashed := Cr} =
+            wasm_jit:counts(),
+        ?assertEqual(N, C, "eight askers compiled the module more than once"),
+        ?assertEqual({0, 0, 0}, {R, F, Cr}),
+        ?assertEqual(1, wasm_jit:shards(I)),
+        Before = map_get(entered, wasm_jit:counts()),
+        Qs = [caller(I) || _ <- lists:seq(1, 8)],
+        ?assertEqual(lists:duplicate(8, {ok, [11]}), release(Qs)),
+        ?assertEqual(8, map_get(entered, wasm_jit:counts()) - Before)
+    after
+        ok = wasm:destroy(I),
+        ?assertEqual(ok, until(fun() -> workers() =:= 0 end, 10000))
+    end.
+
+%% The property the `wanted/2` fix rests on: what to compile is read in the
+%% calling process, whose dictionary holds it, and copied to the worker before
+%% the caller can die.
+%%
+%% This passes on the parent commit, which read `executed/1` in the same place,
+%% so it is a guard rather than a reproduction and is mutation-tested instead:
+%% move `wanted/2` into `compiler_loop/0` and it fails.
+%%
+%% Ordinary compilation, not `compile_whole`, because `wanted/2` answers `[]`
+%% for that without reading anything caller-local, and the case would then
+%% assert nothing at all.
+a_compile_outlives_the_process_that_asked_for_it(_) ->
+    a_compile_outlives_the_process_that_asked_for_it(3, 1).
+
+a_compile_outlives_the_process_that_asked_for_it(0, _) ->
+    ct:fail("never suspended the compiler before it published");
+a_compile_outlives_the_process_that_asked_for_it(Tries, Salt) ->
+    ?assertEqual(ok, until(fun() -> workers() =:= 0 end, 10000)),
+    wasm_jit:reset_counts(),
+    %% `f` calls 200 helpers, so 201 functions are executed and none of the rest
+    %% is. A two-function compile would finish before this could suspend it.
+    M = build(pair_wat(257, 200, Salt)),
+    Self = self(),
+    {C, Mon} = spawn_monitor(
+                 fun() ->
+                     {ok, I} = wasm:instantiate(M, #{}, opts()),
+                     {ok, [11]} = wasm:call(I, ~"f", [10]),
+                     Self ! {ask_returned, self()},
+                     receive stop -> ok end
+                 end),
+    receive {ask_returned, C} -> ok after 60000 -> ct:fail(no_ask) end,
+    %% Establish the schedule rather than hope for it: the caller must die while
+    %% the worker is holding the work and before it publishes.
+    case suspend_worker() of
+        error ->
+            exit(C, kill),
+            receive {'DOWN', Mon, process, C, _} -> ok end,
+            a_compile_outlives_the_process_that_asked_for_it(Tries - 1, Salt + 1);
+        {ok, W} ->
+            exit(C, kill),
+            receive {'DOWN', Mon, process, C, _} -> ok after 10000 -> ct:fail(alive) end,
+            true = erlang:resume_process(W),
+            ?assertEqual(ok, until(fun() -> compiled() >= 201 end, 60000)),
+            ?assertEqual(201, compiled(),
+                         "the worker compiled something other than what the "
+                         "dead caller had run"),
+            %% Which indices, not only how many. A fresh instance adopts what
+            %% was published; `f` was run and is compiled, `g` was not and is
+            %% not, and `generational_entry/3` bumps `entered` only when
+            %% generated code returns or traps -- `{error, not_compiled}` falls
+            %% through to the interpreter untouched.
+            {ok, J} = wasm:instantiate(M, #{}, opts()),
+            try
+                E0 = map_get(entered, wasm_jit:counts()),
+                ?assertEqual({ok, [11]}, wasm:call(J, ~"f", [10])),
+                E1 = map_get(entered, wasm_jit:counts()),
+                ?assertEqual(1, E1 - E0, "the selected function was not compiled"),
+                ?assertEqual({ok, [17]}, wasm:call(J, ~"g", [10])),
+                ?assertEqual(0, map_get(entered, wasm_jit:counts()) - E1,
+                             "a function the caller never ran was compiled")
+            after
+                ok = wasm:destroy(J)
+            end
+    end.
+
 the_ring_keeps_only_the_newest(_) ->
     ok = wasm_code_slots:clear_diagnostics(),
     [ok = wasm_code_slots:record_diagnostic(Seq, refused, {k, Seq},
@@ -250,8 +380,8 @@ the_ring_keeps_only_the_newest(_) ->
 
 the_ring_normalises_what_it_is_given(_) ->
     ok = wasm_code_slots:clear_diagnostics(),
-    M = build(many_wat(4 * max_funs() + 4)),
-    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+    M = build(many_wat(max_funs() + 1)),
+    {ok, I} = wasm:instantiate(M, #{}, (sync(whole()))#{compile_shards => 1}),
     {ok, _} = wasm:call(I, ~"f", [10]),
     [{refused, _, Reason}] = wasm_jit:diagnostics(),
     %% Small, and measured with `flat_size/1`. Not `erts_debug:size/1`, which
@@ -297,11 +427,7 @@ compiled() -> map_get(compiled, wasm_jit:counts()).
 
 %% `f` plus N-1 more, none of them exported, all of them eligible. Every one is
 %% compiled because `compile_whole` asks for what exists rather than what ran.
-%%
-%% Synchronous compilation only. `wasm_jit:spawn_compile/2` reads
-%% `wasm_instance:executed/1` directly rather than going through `wanted/2`, so
-%% the asynchronous path compiles what ran whatever `compile_whole` says. The
-%% cases that need a large unit off the calling process use `called_wat/1`.
+
 many_wat(N) ->
     iolist_to_binary(
       ["(module (func (export \"f\") (param i32) (result i32)
@@ -323,18 +449,84 @@ lopsided_wat(Small, Big) ->
        ")",
        ")"]).
 
-%% As `many_wat/1`, and `f` calls every one of them, so they are all *executed*
-%% and the asynchronous path -- which compiles what ran and not what exists --
-%% sees the whole module.
-called_wat(N) ->
+%% `f` at 0 calls `Calls` helpers, so exactly `Calls + 1` functions are executed
+%% and `g` at 1 is exported and never among them. `Salt` only changes the bytes,
+%% so a retry gets a module identity of its own rather than adopting what the
+%% previous round published.
+pair_wat(N, Calls, Salt) ->
     iolist_to_binary(
       ["(module (func (export \"f\") (param i32) (result i32)",
        [[" i32.const 0 call ", integer_to_list(I), " drop"]
-        || I <- lists:seq(1, N - 1)],
-       " local.get 0 i32.const 1 i32.add)",
+        || I <- lists:seq(2, Calls + 1)],
+       " local.get 0 i32.const ", integer_to_list(Salt), " i32.sub",
+       " i32.const ", integer_to_list(Salt), " i32.add i32.const 1 i32.add)",
+       "(func (export \"g\") (param i32) (result i32)"
+       " local.get 0 i32.const 7 i32.add)",
        [["(func (param i32) (result i32) local.get 0 i32.const ",
-         integer_to_list(I rem 100), " i32.add)"] || I <- lists:seq(2, N)],
+         integer_to_list(I rem 100), " i32.add)"] || I <- lists:seq(3, N)],
        ")"]).
+
+%% A process that instantiates nothing and waits to be released, so eight of
+%% them can be made to call at the same moment rather than in a queue.
+caller(I) ->
+    Self = self(),
+    spawn_monitor(fun() ->
+                      Self ! {ready, self()},
+                      receive go -> ok end,
+                      Self ! {done, self(), wasm:call(I, ~"f", [10])}
+                  end).
+
+release(Ps) ->
+    [receive {ready, P} -> ok after 10000 -> ct:fail(never_ready) end
+     || {P, _} <- Ps],
+    [P ! go || {P, _} <- Ps],
+    [receive
+         {done, P, R} -> demonitor(Mon, [flush]), R;
+         {'DOWN', Mon, process, P, Why} -> ct:fail({caller_died, Why})
+     after 60000 -> ct:fail(never_answered)
+     end || {P, Mon} <- Ps].
+
+workers() ->
+    proplists:get_value(active, supervisor:count_children(wasm_jit_sup)).
+
+%% The one process holding a slot in `loading`, suspended so it cannot publish.
+%%
+%% It spins, because the worker is not holding the slot yet when the caller
+%% returns: `spawn_compile/2` sends it a message and `claim_loading/3` is a
+%% `gen_server` call the worker has still to make. Looking once finds every slot
+%% free and concludes, wrongly, that nothing is compiling. It gives up when the
+%% slot is already `resident`, which is the race genuinely lost, and the caller
+%% retries with a module of its own.
+suspend_worker() -> suspend_worker(erlang:monotonic_time(millisecond) + 5000).
+
+suspend_worker(Deadline) ->
+    case loading_owners() of
+        [W | _] ->
+            %% `suspend_process/1` raises on a process that has already
+            %% exited, which here is just the race lost.
+            try erlang:suspend_process(W) of
+                true ->
+                    case is_process_alive(W) of
+                        true -> {ok, W};
+                        false -> error
+                    end;
+                _ -> error
+            catch
+                _:_ -> error
+            end;
+        [] ->
+            case compiled() > 0 orelse
+                 erlang:monotonic_time(millisecond) >= Deadline of
+                true -> error;
+                false -> timer:sleep(1), suspend_worker(Deadline)
+            end
+    end.
+
+loading_owners() ->
+    [Pid || {_N, _G, {loading, _}, Leases} <- ets:tab2list(wasm_code_slots),
+            Pid <- maps:values(Leases), is_pid(Pid)].
+
+opts() -> #{compile => true, compile_after => 1}.
 
 build(Wat) ->
     {ok, P} = wasm_wat:module(Wat),

--- a/test/wasm_jit_lifetime_SUITE.erl
+++ b/test/wasm_jit_lifetime_SUITE.erl
@@ -39,6 +39,11 @@ all() ->
      destroying_an_instance_gives_its_slot_lease_back,
      a_caller_that_never_destroys_keeps_a_bounded_entry_cache,
      a_module_split_across_shards_answers_the_same,
+     every_tier_bounds_recursion_at_the_same_depth,
+     a_per_call_max_depth_is_honoured_by_a_compiled_module,
+     a_crossing_does_not_roll_back_host_calls,
+     cross_instance_recursion_is_bounded,
+     a_crossing_without_a_budget_starts_where_it_is_told,
      a_profile_sets_what_you_did_not,
      an_unknown_profile_is_a_value_not_a_crash,
      both_engines_answer_the_same_bad_arguments].
@@ -616,6 +621,278 @@ serve() ->
         stop ->
             ok
     end.
+
+%% `max_depth` has to mean the same thing whichever tier is running.
+%%
+%% It did not. Two mutually recursive functions at `max_depth => 1000` reached
+%% 999 frames interpreted, 1000 compiled, and **99,999** when one of the two was
+%% compiled and the other was not: a crossing published a relative depth and the
+%% check compared it against an absolute ceiling, so every round trip started
+%% again. For an untrusted guest that is unbounded recursion.
+%%
+%% Bounded recursion with a base case, not a search: on the parent the mixed arm
+%% does not trap at all, so an unbounded version would hang rather than fail.
+every_tier_bounds_recursion_at_the_same_depth(_) ->
+    Plain = build(mutual_wat(plain)),
+    Mixed = build(mutual_wat(mixed)),
+    %% First, and on a clean slot table, because the arms below leave the module
+    %% resident and a later instance would adopt rather than compile: the mixed
+    %% module really is mixed. `b` reads an exported mutable global, which the
+    %% generator refuses with `global_get_ref`, so exactly one of the two is
+    %% compiled. Without this the case could pass by never splitting the tiers.
+    wasm_test_slots:reset(),
+    wasm_jit:reset_counts(),
+    {ok, I} = wasm:instantiate(Mixed, #{}, depth_opts()),
+    try
+        {ok, _} = wasm:call(I, ~"a", [2]),
+        {ok, _} = wasm:call(I, ~"a", [2]),
+        ?assertEqual(1, map_get(compiled, wasm_jit:counts()),
+                     "the mixed module compiled both functions or neither")
+    after
+        ok = wasm:destroy(I)
+    end,
+    %% `a(N)` is N+1 frames: itself and one per level. At `max_depth => 8` the
+    %% deepest that fits is `a(7)`, and `a(8)` is one too many.
+    [begin
+         wasm_jit:reset_counts(),
+         ?assertEqual({ok, [7]}, depth_call(M, Opts, 7), Name),
+         ?assertMatch({error, #{kind := call_stack_exhausted}},
+                      depth_call(M, Opts, 8), Name)
+     end
+     || {Name, M, Opts} <- [{interpreted, Plain, #{max_depth => 8}},
+                            {compiled, Plain, depth_opts()},
+                            {mixed, Mixed, depth_opts()}]],
+    ok.
+
+%% Generated code reads its ceiling from the instance, so an invocation that
+%% asks for a lower one has to interpret rather than quietly get the higher.
+%% `entry/3` refuses compiled entry for exactly that reason, as it already does
+%% for finite fuel.
+a_per_call_max_depth_is_honoured_by_a_compiled_module(_) ->
+    wasm_test_slots:reset(),
+    M = build(mutual_wat(plain)),
+    {ok, I} = wasm:instantiate(M, #{}, depth_opts()),
+    try
+        %% Resident and entered at the instance's own limit of 8.
+        {ok, _} = wasm:call(I, ~"a", [2]),
+        {ok, _} = wasm:call(I, ~"a", [2]),
+        wasm_jit:reset_counts(),
+        %% Four frames fit; five do not, at the limit this *call* asked for.
+        ?assertMatch({ok, _}, wasm:call(I, ~"a", [3], #{max_depth => 4})),
+        ?assertMatch({error, #{kind := call_stack_exhausted}},
+                     wasm:call(I, ~"a", [4], #{max_depth => 4})),
+        ?assertEqual(0, map_get(entered, wasm_jit:counts()),
+                     "a call that overrode max_depth still entered generated "
+                     "code, where the override cannot be seen")
+    after
+        ok = wasm:destroy(I)
+    end.
+
+%% A guard rather than a reproduction: it passes on the parent, which does not
+%% touch the budget at a crossing at all. What it pins is the shape of the fix.
+%% The crossing publishes the depth into the budget and takes only the depth
+%% back; restoring the whole tuple would put the host-call count back with it,
+%% and a compiled function could then spend `max_host_calls` again on every
+%% return.
+a_crossing_does_not_roll_back_host_calls(_) ->
+    wasm_test_slots:reset(),
+    M = build(host_loop_wat()),
+    Imports = #{{~"env", ~"tick"} => fun(_Ctx, []) -> {ok, []} end},
+    {ok, I} = wasm:instantiate(M, Imports,
+                               (depth_opts())#{max_depth => 64,
+                                               max_host_calls => 10}),
+    try
+        %% Ten are allowed; the eleventh is not, however many crossings it took
+        %% to get there.
+        ?assertMatch({error, #{kind := host_call_limit}},
+                     wasm:call(I, ~"a", [20]))
+    after
+        ok = wasm:destroy(I)
+    end.
+
+%% The branch nothing else reaches. A guard, and it passes on the parent.
+%%
+%% Every other case here enters through `wasm:call/4`, which always installs a
+%% `?BUDGET`, so none of them touches this branch at all. This calls the crossing
+%% directly, with no budget in the process, and asserts both halves together: the
+%% nested interpreter starts at the absolute depth it was given, *and* it keeps
+%% the instance's whole ceiling.
+%%
+%% Both halves, because either alone is right by accident. The parent paired a
+%% reduced ceiling with a zero base and this one pairs an absolute base with the
+%% full ceiling, and the two allow exactly the same number of frames -- which is
+%% why the parent passes. What fails is doing half of it: an absolute base with
+%% the ceiling still reduced allows `max_depth - 2 * Depth`.
+a_crossing_without_a_budget_starts_where_it_is_told(_) ->
+    M = build(mutual_wat(plain)),
+    {ok, I} = wasm:instantiate(M, #{}, #{max_depth => 8}),
+    try
+        ?assertEqual(undefined, get(wasm_budget),
+                     "this case is only meaningful without a budget"),
+        Mut = wasm_instance:mut(I),
+        %% `a(1)` is two frames. Handed depth 6 it takes 7 and 8 and returns;
+        %% handed 7 it would need 9 and traps. `a` is function index 0.
+        ?assertEqual({ok, [1]},
+                     wasm_error:capture(
+                       fun() ->
+                           {R, _} = wasm_exec:call_out(I, Mut, 0, [1], 6,
+                                                       ?MODULE, 0),
+                           {ok, R}
+                       end)),
+        ?assertMatch({error, #{kind := call_stack_exhausted}},
+                     wasm_error:capture(
+                       fun() ->
+                           {R2, _} = wasm_exec:call_out(I, Mut, 0, [1], 7,
+                                                        ?MODULE, 0),
+                           {ok, R2}
+                       end))
+    after
+        ok = wasm:destroy(I)
+    end.
+
+%% `call_out/7` names a generated module so the interpreter it crosses into can
+%% call back the other way. This suite stands in for one: nothing here is
+%% compiled, so every callee is `not_compiled` and stays interpreted.
+invoke(_Inst, _Mut, _Idx, _Args, _Depth, _Gen) -> {error, not_compiled}.
+
+%% Two instances calling each other through a table one of them exports.
+%%
+%% `indirect_out/9`'s foreign branch ignored the depth it was given, and
+%% `foreign_call/5` never published the caller's, so a pair of instances could
+%% recurse for ever inside `max_depth`. On the parent both arms below reach 9
+%% frames against a limit of 8, and keep going.
+%%
+%% Depth only. Fuel is a separate defect -- a foreign callee that throws loses
+%% its final fuel value, because only `leave/2` publishes and `uncaught/1` does
+%% not -- and asserting it here would assert a bug this commit does not fix.
+cross_instance_recursion_is_bounded(_) ->
+    wasm_test_slots:reset(),
+    [begin
+         wasm_jit:reset_counts(),
+         {IA, IB} = linked_pair(Opts),
+         try
+             %% Bounded by a counter with a base case: on the parent the depth
+             %% resets, so an unbounded recursion would not stop and the case
+             %% would hang rather than fail.
+             ?assertEqual({ok, [7]}, wasm:call(IA, ~"a", [7]), Name),
+             ?assertMatch({error, #{kind := call_stack_exhausted}},
+                          wasm:call(IA, ~"a", [8]), Name)
+         after
+             ok = wasm:destroy(IB), ok = wasm:destroy(IA)
+         end
+     end || {Name, Opts} <- [{interpreted, #{max_depth => 8}},
+                             {compiled, depth_opts()}]],
+    %% And the compiled arm reached the branch it names. Without this it could
+    %% fall back to `foreign_call/5`, still fail on the parent, still pass here,
+    %% and never touch `indirect_out/9`.
+    wasm_test_slots:reset(),
+    wasm_jit:reset_counts(),
+    {module, _} = code:ensure_loaded(wasm_exec),
+    1 = erlang:trace_pattern({wasm_exec, indirect_out, 9}, true, [call_count]),
+    try
+        {IA, IB} = linked_pair(depth_opts()),
+        try
+            {ok, _} = wasm:call(IA, ~"a", [2]),
+            {ok, _} = wasm:call(IA, ~"a", [2]),
+            ?assert(map_get(entered, wasm_jit:counts()) >= 1,
+                    "the compiled arm never entered generated code"),
+            {call_count, N} = erlang:trace_info({wasm_exec, indirect_out, 9},
+                                                call_count),
+            ?assert(N > 0, "generated code never reached indirect_out/9")
+        after
+            ok = wasm:destroy(IB), ok = wasm:destroy(IA)
+        end
+    after
+        _ = erlang:trace_pattern({wasm_exec, indirect_out, 9}, false,
+                                 [call_count])
+    end.
+
+%% `a` in one instance and `b` in another, each calling the other through the
+%% table the first exports and the second imports.
+linked_pair(Opts) ->
+    {ok, IA} = wasm:instantiate(build(peer_wat(0)), #{}, Opts),
+    {ok, T} = wasm:extern(IA, ~"t"),
+    {ok, IB} = wasm:instantiate(build(peer_wat(1)),
+                                #{{~"env", ~"t"} => T},
+                                (maps:remove(compile, Opts))#{link => IA}),
+    {IA, IB}.
+
+%% Slot 0 holds the importer's function, slot 1 the exporter's, so each side
+%% calls the other by index.
+peer_wat(0) ->
+    ~"(module
+        (type $ii (func (param i32) (result i32)))
+        (table (export \"t\") 2 funcref)
+        (elem (i32.const 1) $a)
+        (func $a (export \"a\") (param i32) (result i32)
+          local.get 0 i32.eqz
+          if (result i32) i32.const 0
+          else local.get 0 i32.const 1 i32.sub i32.const 0
+               call_indirect (type $ii) i32.const 1 i32.add end))";
+peer_wat(1) ->
+    ~"(module
+        (type $ii (func (param i32) (result i32)))
+        (import \"env\" \"t\" (table $t 2 funcref))
+        (elem (table $t) (i32.const 0) func $b)
+        (func $b (param i32) (result i32)
+          local.get 0 i32.eqz
+          if (result i32) i32.const 0
+          else local.get 0 i32.const 1 i32.sub i32.const 1
+               call_indirect (type $ii) i32.const 1 i32.add end))".
+
+%% `a` calls the import, then `b`, which calls `a`. With `b` reading an exported
+%% mutable global it is refused, so every other level is a crossing and every
+%% level makes a host call.
+host_loop_wat() ->
+    ~"(module
+        (import \"env\" \"tick\" (func $tick))
+        (global $g (export \"g\") (mut i32) (i32.const 0))
+        (func $a (export \"a\") (param i32) (result i32)
+          call $tick
+          local.get 0 i32.eqz
+          if (result i32) i32.const 0
+          else local.get 0 i32.const 1 i32.sub call $b i32.const 1 i32.add end)
+        (func $b (param i32) (result i32)
+          global.get $g drop
+          local.get 0 i32.eqz
+          if (result i32) i32.const 0
+          else local.get 0 i32.const 1 i32.sub call $a i32.const 1 i32.add end))".
+
+depth_opts() -> #{max_depth => 8, compile => true, compile_after => 1,
+                  compile_sync => true, compile_shards => 1}.
+
+%% Warmed, so a compiled arm is actually compiled before the depths are probed.
+depth_call(M, Opts, N) ->
+    {ok, I} = wasm:instantiate(M, #{}, Opts),
+    try
+        _ = wasm:call(I, ~"a", [1]),
+        _ = wasm:call(I, ~"a", [1]),
+        wasm:call(I, ~"a", [N])
+    after
+        ok = wasm:destroy(I)
+    end.
+
+%% `a` calls `b` calls `a`, one frame per level, with a base case at zero.
+%%
+%% `mixed` gives `b` a read of an exported mutable global, which becomes a
+%% reference cell rather than a value and is refused with
+%% `{unsupported, global_get_ref}`. `a` still compiles, so every level crosses
+%% the boundary.
+mutual_wat(Kind) ->
+    Read = case Kind of
+               mixed -> " global.get $g drop";
+               plain -> ""
+           end,
+    iolist_to_binary(
+      ["(module (global $g (export \"g\") (mut i32) (i32.const 0))
+         (func $a (export \"a\") (param i32) (result i32)
+           local.get 0 i32.eqz
+           if (result i32) i32.const 0
+           else local.get 0 i32.const 1 i32.sub call $b i32.const 1 i32.add end)
+         (func $b (export \"b\") (param i32) (result i32)", Read,
+       "   local.get 0 i32.eqz
+           if (result i32) i32.const 0
+           else local.get 0 i32.const 1 i32.sub call $a i32.const 1 i32.add end))"]).
 
 %%% -------------------------------------------------------------- helpers ---
 


### PR DESCRIPTION
## Why

A CPython 3.12 cold start takes 19.2 s and allocates 5.45 G heap words. We
measured where that goes first.

Almost all of it is the interpreter running CPython's own start-up: 383 million
operations. Lowering is 0.03%, instantiation 0.14%, and a second request to a
warm instance is free. There is nothing to gain at the edges. The compiled tier
removes that cost, but it never ran on CPython, never said why, and could not
keep the result.

(An earlier commit here put lowering at 39%. That was the instrument:
`erts_debug:size/1`, called inside the measured window, allocates 172 words per
word it walks. `PERF.md` has the correction.)

## What was wrong

- **The refusal was not a value.** `wasm_core:forms/8` catches
  `throw:{limit, _}` and nothing throws it, so a module past `?MAX_FUNS` escaped
  as an exception. Under `compile_sync` it reached the embedder; otherwise it
  vanished into `compiler_loop/0` while `counts()` stayed at zero.
- **Nothing split.** `auto_shards/1` returned 1 always, and `bins/2` balanced IR
  words without counting functions, so a shard count could be overrun anyway.
- **`compile_whole` was synchronous only.** `spawn_compile/2` read
  `wasm_instance:executed/1` instead of `wanted/2`.
- **The name pool was sized for QuickJS.** At 2048, CPython's 2,333 functions
  split in two, and only the last unit of a chain is cached. The guest was
  recompiled on every node.
- **`max_depth` did not survive a tier boundary.** Same program, limit 1000:
  interpreted stopped at 999, compiled at 1,000, half-compiled at 99,999. For an
  untrusted guest that is unbounded recursion.
- **The admission ceiling moved with the name pool.** Raising the pool raised
  what the runtime accepts from 8,192 functions to 16,384, which admits a
  request we measured at 33 GB resident, paging, publishing nothing.

## What we did

- `forms/8` catches `error:{limit, _}`, the class actually raised.
- `auto` splits at `ceil(NFuns / max_funs)`; `bins/2` takes the lightest bin
  that can still take a function.
- `spawn_compile/2` goes through `wanted/2`.
- `?MAX_FUNS` is 4096, so CPython's hot set is one unit, and one unit is the
  only kind the disk cache accepts.
- `compile/4` answers `{ok, Slot} | retry | {refused, R} | {failed, R}` and never
  raises for a known outcome. `counts/0` gains `refused`, `failed`, `crashed`;
  `diagnostics/0` gives the reasons.
- One helper carries the depth into every nested invocation, including the two
  foreign ones. `entry/3` refuses compiled entry when a call overrides
  `max_depth`. The ABI is bumped: a cached artifact would bring back the old
  behaviour.
- `?MAX_COMPILE_FUNS` is a separate constant, counted before anything is
  lowered.

## Results

Both guests, `compile_shards` at `auto`, one emulator per arm:

| | QuickJS | CPython |
| --- | ---: | ---: |
| units | 1 | 1 |
| `entered` on the first `_start` | 1 | 1 |
| allocated | 555 K, from 28.1 M | **238 M, from 5.45 G** |
| clean wall | 14 ms, from 53 | **3,600 ms, from 19,220** |

CPython by unit count. Allocation is the claim; the walls are single runs.

| units | allocated | clean wall | compile |
| ---: | ---: | ---: | ---: |
| 4 | 305,591,745 | 4,851 ms | 464 s |
| 2 | 259,856,472 | 4,813 ms | 637 s |
| 1 | 237,579,662 | 3,600 ms | 1,228 s |

The compile is now paid once per node: a second emulator against the same cache
reaches compiled code in **2 s** instead of 1,105.

Depth, same program at `max_depth => 1000`:

| arm | before | after |
| --- | ---: | ---: |
| interpreted | 999 | 999 |
| compiled | 1,000 | 999 |
| half-compiled | 99,999 | 999 |

## Checks

`make suites`, then compile, lint, xref and dialyzer clean, and **458 CT cases
with no skips**.

Each reproduction case fails on its parent commit: the synchronous refusal
raises there, the asynchronous one reports nothing, `compile_whole` compiles 1
function instead of 257, the depth arms disagree, two instances return where
they should trap, and an over-ceiling request answers `retry` after 8,193
lowerings instead of `refused` after none. Cases that only guard a behaviour say
so; one has no parent to fail against and is mutation tested instead.

`realbench.erl` on QuickJS, six interleaved pairs in both orderings, every half
under load average 8: this branch wins four, the means differ by 0.1%, and the
spread inside one arm is wider than the gap between arms.

CI was also red for a reason that was not this branch. Upstream `testsuite`
moved to `f4c5737` and added an assertion that a type may declare only one
supertype; the binary format encodes them as a vector and validation walked
whatever it held. Branch and main failed the same way, so it was a gap on main.
`wasm_gc_SUITE` now pins it without the external checkout.

## Not done, with the reason

- **A heap fuse on the compiler.** `compile:forms/2` spawns its own process, so
  a `max_heap_size` on ours bounds a process that only waits: 0.34 GB of a 6 GB
  compile. `no_spawn_compiler_process` makes it visible and costs 293 s against
  167, because the compiler's child never collects. Neither option is worth
  taking.
- **`compile_whole` on CPython's whole module.** Inside the four-unit ceiling
  now and still refused by admission, which is right: 33 GB in eleven minutes,
  nothing published.
- **Fuel and mutable state across a foreign call.** A callee that spends fuel
  and throws loses its final value; `foreign_call/5` reads committed state, not
  in-flight state.
- **`#st{}` at 11 words per instruction**, 77% of an interpreted CPython run. It
  matters for guests that cannot be compiled.
