### PR TITLE
Run the OTP compiler in a process we own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### The compiled tier runs the OTP compiler in a process it owns
+
+`compile:forms/2` runs its passes in a process of its own and gives a caller no
+way to configure it, so anything set on the process `wasm_jit` spawns bound a
+process that only waits: 141 MB watched against 2,055 MB spent. The tier now
+declines that spawn with `no_spawn_compiler_process` and makes the same
+short-lived process itself, measured at 0.9% over five interleaved samples.
+
+Two things follow. A heap ceiling can be set, with
+`application:set_env(wasm, compile_max_heap_words, Words)`; a compile over it is
+refused, which means the guest interprets and answers as before, and
+`wasm_jit:diagnostics/0` says `{limit, {compile_memory, Words}}`. It is **off by
+default**: see [the compiled tier guide](docs/compiled-tier.md) for what it does
+and does not bound.
+
+And a compile can now be stopped. `compile:forms/2` spawns its worker with
+`spawn_monitor/1`, which does not link, so until now a compiler killed by
+`application:stop(wasm)` or by its supervisor left the OTP compiler running to
+completion holding its copy of the forms, with nothing able to see or stop it.
+
+`wasm_jit:compile_limits/0` reports `max_heap_words`, and `max_heap_words/0`
+answers it on its own.
+
 ## 0.2.2
 
 Documentation only. No code changed.

--- a/bench/paths/README.md
+++ b/bench/paths/README.md
@@ -473,6 +473,56 @@ Interleave it against the previous commit, five pairs, and compare minimums.
 The loop cannot see this class of regression, and neither can any of the call
 arms.
 
+## Where a compile's memory is spent, and what a ceiling would cost
+
+`PERF.md` records that a `max_heap_size` ceiling on the process `wasm_jit`
+spawns sees 0.34 GB of a compile whose node reaches 6.19 GB, because
+`compile:forms/2` runs its passes in a process of its own, and that moving the
+work onto that same long-lived coordinator with `no_spawn_compiler_process`
+costs 75% more compile time. `compileheap` asks the question that experiment did
+not: what does the same option cost in a *fresh, disposable* process of our own,
+which is the lifecycle OTP's own child already has?
+
+```sh
+erlc -I _build/default/lib -o bench/paths bench/paths/compileheap.erl
+erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \
+    -run compileheap main test/fixtures/lang/qjs.wasm 5
+```
+
+Prove the instrument first. It groups collection events by pid, which
+`allocwords` does not and cannot, since its estimator pairs a start with the end
+after it and that is sound only within one process:
+
+```sh
+erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \
+    -run compileheap main validate
+```
+
+Three arms compile the same `Core`, built once before any of them: `otp` as
+`wasm_core:module/9` calls it today, `inline` with
+`no_spawn_compiler_process` on the measuring process, and `child` with the same
+option in a fresh process under the `max_heap_size` map that would ship. The
+gate is one ordered rule on `R = child min / otp min`, from the **clean,
+untraced** walls: `R =< 1.10` ships, `1.10 < R =< 1.20` ships opt-in, `R > 1.20`
+stops.
+
+Four things it will not let you get wrong, each of which cost a draft:
+
+- **The wall it gates on is untraced.** The arms differ in how many processes
+  exist and so in how many collection events the instrument sees, which is the
+  same trap `pyarms` records as "the traced wall is not the wall".
+- **`[procs, set_on_spawn]` delivers zero collection events.** A child inherits
+  only the flags its parent carries, so the trace needs
+  `[procs, garbage_collection, set_on_spawn, monotonic_timestamp]`, and that
+  last flag makes every message a `trace_ts` tuple with a timestamp appended.
+  A harness matching `{trace, ...}` matches nothing and silently finds no child.
+- **The `otp` arm's allocation is a floor, printed with a `>`.** Its compiler is
+  spawned inside `compile:do_compile/2` and exits with its result, so no closing
+  collection can be forced and the final live set is unmeasured.
+- **The sampled peak is a lower bound**, always: a peak between two 50 ms
+  samples is invisible, and so is the memory the collector needs while
+  collecting. Never size a ceiling by it.
+
 ## Short notes
 
 - The box matters more than most of these differences. Taken here at load

--- a/bench/paths/compileheap.erl
+++ b/bench/paths/compileheap.erl
@@ -1,0 +1,712 @@
+-module(compileheap).
+-moduledoc """
+Where a compile's memory is spent, and what a ceiling on it would cost.
+
+`compile:forms/2` runs its passes in a process of its own, so a `max_heap_size`
+set on the process `wasm_jit` spawns bounds a process that only waits:
+`test/audit/PERF.md` records 0.34 GB of heap on our side of a compile whose node
+reached 6.19 GB. The recorded alternative, `no_spawn_compiler_process` on that
+same long-lived coordinator, moved the growth where a ceiling can see it and
+cost 75% more compile time. Neither shipped.
+
+This asks the question that experiment did not ask: what does it cost to run
+`no_spawn_compiler_process` in a *fresh, disposable* process of our own, which
+is the lifecycle OTP's own child already has? The coordinator holds the
+instance, the whole unit IR and the Core term and lives through the compile; a
+child that receives only the Core allocates, answers and exits.
+
+    erlc -I _build/default/lib -o bench/paths bench/paths/compileheap.erl
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run compileheap main <guest.wasm> [samples] [<ir-words> | fN | all]
+    erl -noshell -pa _build/default/lib/wasm/ebin -pa bench/paths \\
+        -run compileheap main validate
+
+The three arms compile the *same* `Core` term, built once before any of them
+runs, so nothing about lowering is inside any window:
+
+  otp     `compile:forms/2` as `wasm_core:module/9` calls it today. OTP spawns.
+  inline  `no_spawn_compiler_process` on the measuring process, which also
+          holds the unit. This is the 293 s row, reproduced.
+  child   the same option in a fresh process holding only the Core, under the
+          `max_heap_size` map that would actually ship, at a size nothing here
+          can reach.
+
+## What each number is worth
+
+**Wall time comes from a second, untraced run.** Tracing charges the arms
+unequally, because they differ in how many processes exist and therefore in how
+many collection events the instrument sees. `bench/paths/pyarms.erl` records the
+same trap in its own words: "The traced wall is not the wall." The gate reads
+the clean wall and nothing else.
+
+**Peak heap is sampled, so it is a lower bound, always.** The quantity
+`max_heap_size` compares against is `total_heap_size` and that is what is
+sampled, but a peak between two samples is invisible, and so is the memory the
+collector needs while collecting.
+
+**Allocated words are per process**, from that process's own collection trace,
+by `allocwords`'s estimator: reclaimed, plus ending live, minus starting live,
+over a window a forced major collection closes at each end.
+
+**The `otp` arm cannot have that window.** Its child is spawned inside
+`compile:do_compile/2` and exits with its result, so nothing can force the
+closing collection. What is reported for it is the reclaimed sum alone, marked
+`lower`. The `inline` and `child` arms are complete, because both boundaries
+are in code this module wrote.
+
+## Proving the instrument before believing it
+
+`main validate` checks the pid-keyed estimator against a known allocation
+happening in two processes at once, which is exactly what `allocwords` cannot
+do: its estimator pairs a start with the end after it, sound only when the
+events come from one process, and `set_on_spawn` interleaves several into one
+mailbox. Run it on the box before the numbers here are believed.
+""".
+
+-export([main/1, validate/0]).
+
+-include_lib("wasm/include/wasm.hrl").
+-include_lib("wasm/include/wasm_exec.hrl").
+
+%% `procs' is what delivers the spawn event that names the process actually
+%% running the compiler, `set_on_spawn' is what makes that process traced at
+%% all, and `garbage_collection' is what the estimator counts. A child inherits
+%% only the flags its parent carries, so dropping any of the three leaves the
+%% collector with nothing: `[procs, set_on_spawn]' alone delivers spawn events
+%% and zero collections.
+%%
+%% `monotonic_timestamp' is for the collection *time*, which no counter carries,
+%% and it changes the message tag to `trace_ts' and appends a timestamp. A
+%% harness matching `{trace, ...}' matches nothing at all.
+-define(FLAGS, [procs, garbage_collection, set_on_spawn, monotonic_timestamp]).
+
+-define(SAMPLE_MS, 50).
+-define(TIMEOUT, 3600000).
+
+%% The map that would ship, at a size nothing here can reach. The gate has to
+%% measure the configuration an embedder would run, and
+%% `include_shared_binaries' is acknowledged to have a cost, so measuring with
+%% it off would price a configuration nobody uses.
+-define(SIZE, (8 bsl 30)).
+
+-define(ARMS, [otp, inline, child]).
+
+%% IR words, which is what the compile's cost tracks. On QuickJS this selects
+%% 10 functions, 385 K IR words and 17.2 M Core words, which compiles in about
+%% 87 seconds and produces 7.06 MB of BEAM: the same order as the 10.9 MB
+%% `PERF.md` records for that guest's 223-function hot set, at a runtime that
+%% permits the 45 compiles a five-sample gate needs. See `build/2`.
+-define(WORDS, 400000).
+
+main(["validate"]) ->
+    case validate() of
+        ok -> init:stop();
+        {error, _} -> init:stop(1)
+    end;
+main([Path]) ->
+    main([Path, "5"]);
+main([Path, N]) ->
+    main([Path, N, integer_to_list(?WORDS)]);
+main([Path, N, Funs]) ->
+    {ok, _} = application:ensure_all_started(wasm),
+    where(),
+    io:format("load before  ~s~n", [load()]),
+    {ok, Bin} = file:read_file(Path),
+    {ok, Mod} = wasm:load(Bin),
+    {ok, Inst} = wasm:instantiate(Mod, wasi_preview1:imports(#{}), #{}),
+    {Unit, Core} = build(Inst, limit(Funs)),
+    %% The IR figure is the sum over the functions' own IR, which is the
+    %% quantity `wasm_jit:split/2' packs shards by and the one the budget
+    %% counts. `flat_size(Unit)' is a different and larger number, because a
+    %% unit entry carries the whole `#fn{}' beside its IR, and reporting that
+    %% one as "IR words" is how the first draft of this harness came to select
+    %% four times the unit it meant to.
+    IrWords = lists:sum([erts_debug:flat_size(IR) || {_P, _I, _F, IR} <- Unit]),
+    io:format("unit         ~w functions, IR ~w words, unit ~w words, "
+              "Core ~w words~n",
+              [length(Unit), IrWords, erts_debug:flat_size(Unit),
+               erts_debug:flat_size(Core)]),
+    Rows = rounds(Core, {Inst, Unit}, list_to_integer(N)),
+    io:format("~nload after   ~s~n", [load()]),
+    report(Rows, length(Unit), IrWords),
+    %% `-run' does not halt the node when the function returns, and a harness
+    %% that prints its whole report and then sits there looks exactly like one
+    %% that hung.
+    init:stop().
+
+%%% ------------------------------------------------------------ the unit ---
+
+limit("all") -> all;
+limit([$f | N]) -> {funs, list_to_integer(N)};
+limit(N) -> {words, list_to_integer(N)}.
+
+%% By IR words rather than by function count, because words are what the cost
+%% tracks: `src/wasm_jit.erl' sizes shards by `erts_debug:flat_size/1' of the
+%% IR for exactly this reason, and the first 402 QuickJS functions by index
+%% carry 8.07 M words where the whole module carries 12.0 M. A count is a poor
+%% handle on a compile whose functions differ by three orders of magnitude.
+take(all, L) -> L;
+take({funs, N}, L) -> lists:sublist(L, N);
+take({words, Budget}, L) -> upto(Budget, L, []).
+
+upto(_Left, [], Acc) -> lists:reverse(Acc);
+upto(Left, [{_F, IR} = H | T], Acc) ->
+    case erts_debug:flat_size(IR) of
+        %% Always at least one, so a budget under the first function still
+        %% builds a unit rather than an empty one.
+        W when W > Left, Acc =/= [] -> lists:reverse(Acc);
+        W -> upto(Left - W, T, [H | Acc])
+    end.
+
+%% `wasm_jit:unit/2` with an empty executed list, which is how it reads "every
+%% eligible function", then cut to `Limit`. Reproduced here rather than
+%% exported, because a bench harness reaching into a private selector is the
+%% harness's problem and not the runtime's.
+%%
+%% **The prefix is chosen for scale, not for realism.** It is a deterministic
+%% prefix of the eligible list and it is not any workload's hot set, which it
+%% does not claim to be. What the gate needs is that all three arms compile the
+%% identical term, and any deterministic selection gives that; what the *size*
+%% has to give is a compile far enough above fixed costs for a ratio to mean
+%% something, without being the shape that pages the box.
+%%
+%% Pass `all` for every eligible function, which for QuickJS is 1,666 of them,
+%% 12.0 M IR words and 106.0 M Core words. That is the `compile_whole` shape,
+%% it reached 5 GB resident in its first minute on a 48 GB box, and it is not
+%% what the tier compiles for anyone. `fN` cuts by function count instead, and
+%% is mostly useful for showing why counting functions is the wrong handle:
+%% QuickJS's first 402 by index carry 8.07 M of the module's 12.0 M words.
+build(Inst, Limit) ->
+    Fns = [F || F <- tuple_to_list(Inst#inst.funcs), is_record(F, fn)],
+    Lowered = [{F, wasm_instance:compiler_ir(F, Inst)} || F <- Fns],
+    Eligible = take(Limit,
+                    [{F, IR} || {F, IR} <- Lowered,
+                                element(1, wasm_core:can_compile(F, IR)) =:= ok]),
+    Unit = [{Pos, F#fn.idx, F, IR}
+            || {Pos, {F, IR}} <- lists:enumerate(0, Eligible)],
+    %% Zero for the stamp, and a name nothing loads: this unit is compiled
+    %% three times and never entered.
+    {ok, Core} = wasm_core:forms(compileheap_unit, Unit, sigs(Inst),
+                                 tsigs(Inst), 0),
+    {Unit, Core}.
+
+sigs(Inst) ->
+    maps:from_list(
+      [{Idx, sig(F)}
+       || {Idx, F} <- lists:enumerate(0, tuple_to_list(Inst#inst.funcs))]).
+
+tsigs(Inst) ->
+    maps:from_list(
+      [{Idx, S}
+       || {Idx, T} <- lists:enumerate(0, tuple_to_list(Inst#inst.types)),
+          S <- [tsig(T)], S =/= undefined]).
+
+tsig(#functype{params = P, results = R}) -> {length(P), length(R)};
+tsig(#subtype{body = #functype{params = P, results = R}}) ->
+    {length(P), length(R)};
+tsig(_) -> undefined.
+
+sig(#fn{nparams = NP, nresults = NR}) -> {NP, NR};
+sig(#hostfn{nparams = NP, nresults = NR}) -> {NP, NR}.
+
+copts() -> [from_core, binary, return_errors].
+
+%%% ---------------------------------------------------------------- arms ---
+
+%% `Bound' says whether this run may force the collections the estimator's
+%% window needs. The clean run says no, so what it times is the shape that
+%% would ship and not the shape that can be accounted for.
+run(otp, Core, _Bound) ->
+    {compile:forms(Core, copts()), []};
+run(inline, Core, _Bound) ->
+    {compile:forms(Core, [no_spawn_compiler_process | copts()]), []};
+run(child, Core, Bound) ->
+    Owner = self(),
+    {Pid, Ref} =
+        spawn_opt(fun () ->
+                      Bound andalso erlang:garbage_collect(),
+                      R = compile:forms(
+                            Core, [no_spawn_compiler_process | copts()]),
+                      %% Closing boundary with `R' still referenced, so the
+                      %% artifact counts as live and not as reclaimed.
+                      Bound andalso erlang:garbage_collect(),
+                      Owner ! {result, self(), R}
+                  end,
+                  [monitor,
+                   {max_heap_size, #{size => ?SIZE, kill => true,
+                                     error_logger => false,
+                                     include_shared_binaries => true}}]),
+    %% By message rather than by exit reason, which is what lets the child
+    %% force its closing collection before it dies. The artifact is a refcounted
+    %% binary either way, so what crosses is a header.
+    receive
+        {result, Pid, R} ->
+            demonitor(Ref, [flush]),
+            {R, [Pid]};
+        {'DOWN', Ref, process, Pid, Why} ->
+            {{error, {compiler_died, Why}}, [Pid]}
+    after ?TIMEOUT ->
+            erlang:error({arm_timeout, child})
+    end.
+
+%%% --------------------------------------------------------- instrumented ---
+
+%% `Live' is what the real coordinator holds for the whole compile: the
+%% instance and the unit IR, beside the Core it is compiling. It is referenced
+%% *after* the compile so it cannot be collected during it, and that is the
+%% whole point of passing it.
+%%
+%% Without it the `inline' arm does not reproduce the row it exists to
+%% reproduce. Measured on one QuickJS function with the runner holding only the
+%% Core, `inline' was 18.7 s against `otp' 18.6, where `PERF.md' has 293 s
+%% against 167. The recorded cost was never the option; it was collecting a
+%% live set this size on every pass.
+instrumented(Arm, Core, Live) ->
+    Owner = self(),
+    Runner = spawn(fun () ->
+                       receive go -> ok end,
+                       erlang:garbage_collect(),
+                       {R, Bounded} = run(Arm, Core, true),
+                       erlang:garbage_collect(),
+                       Owner ! {done, self(), R, Bounded, held(Live)}
+                   end),
+    %% Matched against 1. A trace that installed nothing answers 0 and then
+    %% confirms whatever story you had, which `PERF.md' records as a trap this
+    %% project has already fallen into once.
+    1 = erlang:trace(Runner, true, ?FLAGS),
+    Runner ! go,
+    %% Seeded from the clock, never from zero. `erlang:monotonic_time/1' has an
+    %% arbitrary origin and on this box reads about -576,460,751,902 ms, so a
+    %% zero seed makes `Now - Last >= ?SAMPLE_MS' false for the next eighteen
+    %% thousand years and every peak comes out 0.0 MB.
+    watch(Runner, #{Runner => 0}, [], erlang:monotonic_time(millisecond)).
+
+%% The sampler is driven by the clock and not by the mailbox being empty.
+%% Leaving it to `after ?SAMPLE_MS' looks right and is not: a compile floods
+%% this mailbox with collection events, every one of them matches a clause, and
+%% the timeout then never fires for as long as the compile is busiest. The
+%% sampler would starve exactly where the peak is.
+watch(Runner, Peaks0, Evs, Last0) ->
+    {Last, Peaks} = maybe_sample(Last0, Peaks0),
+    receive
+        {trace_ts, _P, spawn, Child, _MFA, _Ts} ->
+            watch(Runner, Peaks#{Child => 0}, Evs, Last);
+        {trace_ts, _, _, _, _, _} ->
+            watch(Runner, Peaks, Evs, Last);
+        {trace_ts, P, Kind, Info, Ts} when Kind =:= gc_minor_start;
+                                           Kind =:= gc_minor_end;
+                                           Kind =:= gc_major_start;
+                                           Kind =:= gc_major_end ->
+            watch(Runner, Peaks, [{P, Kind, Info, Ts} | Evs], Last);
+        {trace_ts, _, _, _, _} ->
+            watch(Runner, Peaks, Evs, Last);
+        {done, Runner, R, Bounded, _Held} ->
+            finish(Runner, Peaks, Evs, R, Bounded)
+    after ?SAMPLE_MS ->
+            watch(Runner, Peaks, Evs, Last)
+    end.
+
+maybe_sample(Last, Peaks) ->
+    Now = erlang:monotonic_time(millisecond),
+    case Now - Last >= ?SAMPLE_MS of
+        true -> {Now, sample(Peaks)};
+        false -> {Last, Peaks}
+    end.
+
+sample(Peaks) ->
+    maps:map(fun (P, Max) ->
+                 case process_info(P, total_heap_size) of
+                     {total_heap_size, S} when S > Max -> S;
+                     _ -> Max
+                 end
+             end, Peaks).
+
+finish(Runner, Peaks, Evs, Result, Bounded) ->
+    %% Waiting for the message, not calling `trace_delivered/1', is the
+    %% barrier. `all' rather than `Runner': the children have exited and their
+    %% events are what this whole collector exists for.
+    Ref = erlang:trace_delivered(all),
+    receive {trace_delivered, all, Ref} -> ok end,
+    All = lists:reverse(drain(Evs)),
+    Complete = [Runner | Bounded],
+    %% Every pid that produced an event, not only the ones a `spawn' event
+    %% named. Trace messages are asynchronous and the runner reports `done'
+    %% once its child has already exited, so a child's spawn event can arrive
+    %% after that and its collections would then be dropped from the accounting
+    %% while still being counted in nothing at all.
+    Pids = lists:usort(maps:keys(Peaks) ++ Bounded ++
+                           [P || {P, _, _, _} <- All]),
+    Per = #{P => per_pid([E || {Q, _, _, _} = E <- All, Q =:= P],
+                         lists:member(P, Complete))
+            || P <- Pids},
+    #{runner => Runner,
+      peaks => Peaks,
+      per_pid => Per,
+      result => Result}.
+
+drain(Acc) ->
+    receive
+        {trace_ts, _P, spawn, _Child, _MFA, _Ts} -> drain(Acc);
+        {trace_ts, _, _, _, _, _} -> drain(Acc);
+        {trace_ts, P, Kind, Info, Ts} when Kind =:= gc_minor_start;
+                                           Kind =:= gc_minor_end;
+                                           Kind =:= gc_major_start;
+                                           Kind =:= gc_major_end ->
+            drain([{P, Kind, Info, Ts} | Acc]);
+        {trace_ts, _, _, _, _} -> drain(Acc)
+    after 0 -> Acc
+    end.
+
+%%% ------------------------------------------------------- the estimator ---
+
+%% One process's events, in order. `allocwords`'s arithmetic, with the
+%% bookkeeping replaced: that module pairs a start with the end that follows it
+%% and says in its own moduledoc why that is sound, "Collections do not nest in
+%% one process". They do interleave across processes, which is what this
+%% grouping is for, and it is the whole of the difference.
+per_pid(Evs, Complete) ->
+    Ends = [{K, I} || {_P, K, I, _T} <- Evs,
+                      K =:= gc_minor_end orelse K =:= gc_major_end],
+    per_pid_1(Ends, Complete, us(gc_time(Evs, Complete))).
+
+per_pid_1([], _Complete, _GcUs) ->
+    #{collections => 0, note => no_collections};
+per_pid_1(Ends, false, GcUs) ->
+    %% No forced boundary at either end, so the starting and ending live sets
+    %% are unknown and only what was reclaimed can be summed. A floor, and
+    %% labelled one wherever it is printed.
+    #{allocated => undefined,
+      reclaimed => lists:sum([w(I, wordsize) || {_, I} <- Ends]),
+      collections => length(Ends),
+      major => length([x || {gc_major_end, _} <- Ends]),
+      gc_us => GcUs,
+      note => lower};
+per_pid_1([{_, Open} | Rest], true, GcUs) ->
+    %% The opening forced major is the boundary, so its own reclamation belongs
+    %% to whatever ran before this window and is dropped.
+    Live0 = live(Open),
+    Live1 = case Rest of
+                [] -> Live0;
+                _ -> live(element(2, lists:last(Rest)))
+            end,
+    Reclaimed = lists:sum([w(I, wordsize) || {_, I} <- Rest]),
+    #{allocated => Reclaimed + Live1 - Live0,
+      reclaimed => Reclaimed,
+      live_before => Live0,
+      live_after => Live1,
+      collections => length(Rest),
+      major => length([x || {gc_major_end, _} <- Rest]),
+      gc_us => GcUs,
+      note => complete}.
+
+%% A start and the end after it, within one process. The opening forced pair is
+%% dropped for the same reason its words are.
+gc_time(Evs, true) -> gc_time_1(drop_pair(Evs), 0);
+gc_time(Evs, false) -> gc_time_1(Evs, 0).
+
+gc_time_1([{P, S, _, T0}, {P, E, _, T1} | Rest], Acc)
+  when (S =:= gc_minor_start orelse S =:= gc_major_start) andalso
+       (E =:= gc_minor_end orelse E =:= gc_major_end) ->
+    gc_time_1(Rest, Acc + (T1 - T0));
+gc_time_1([_ | Rest], Acc) -> gc_time_1(Rest, Acc);
+gc_time_1([], Acc) -> Acc.
+
+drop_pair([_, _ | Rest]) -> Rest;
+drop_pair(_) -> [].
+
+us(T) -> erlang:convert_time_unit(T, native, microsecond).
+
+live(I) -> w(I, heap_size) + w(I, old_heap_size).
+
+w(Info, Key) -> proplists:get_value(Key, Info, 0).
+
+%%% --------------------------------------------------------------- clean ---
+
+%% The number the gate reads. One fresh process, no tracing, no sampler, and
+%% the arm in the shape that would ship.
+clean(Arm, Core, Live) ->
+    Owner = self(),
+    Pid = spawn(fun () ->
+                    {T, {R, _}} = timer:tc(fun () -> run(Arm, Core, false) end),
+                    Owner ! {clean, self(), T, R, held(Live)}
+                end),
+    receive
+        {clean, Pid, T, R, _Held} -> {T, R}
+    after ?TIMEOUT -> erlang:error({clean_timeout, Arm})
+    end.
+
+%% Touch it, cheaply, so it is live from the closure to here and the collector
+%% has to copy it on every pass in between. A comment saying "kept alive" over
+%% an unused variable is not the same thing: the compiler is entitled to drop
+%% one, and this is the arm's whole independent variable.
+held({Inst, Unit}) -> {element(1, Inst), length(Unit)}.
+
+%%% ------------------------------------------------------------- rounds ---
+
+%% Interleaved, not batched, and in both orderings, so a drift in the box's
+%% load lands on every arm rather than on whichever ran last.
+rounds(Core, Live, N) ->
+    lists:append([round_(Core, Live, I, N) || I <- lists:seq(1, N)]).
+
+%% The instrumented run happens once per arm and the clean run twice, once in
+%% each order. The gate reads clean walls only, so that is what needs the
+%% ordering; the memory figures do not, and an instrumented compile is the more
+%% expensive of the two. Doing both twice was 12 compiles a sample where 9 say
+%% the same thing.
+round_(Core, Live, I, N) ->
+    io:format("~nsample ~w/~w  load ~s~n", [I, N, load()]),
+    %% Bound, not written as one `++' expression: Erlang does not specify the
+    %% evaluation order of its operands and evaluates them right to left here,
+    %% so the reversed pass ran first and the log read backwards.
+    Forward = [one(Arm, Core, Live) || Arm <- ?ARMS],
+    Reversed = [clean_only(Arm, Core, Live) || Arm <- lists:reverse(?ARMS)],
+    Forward ++ Reversed.
+
+one(Arm, Core, Live) ->
+    #{result := R} = M = instrumented(Arm, Core, Live),
+    {CleanUs, CleanR} = clean(Arm, Core, Live),
+    Row = M#{arm => Arm,
+             clean_us => CleanUs,
+             bytes => byte_size(bin_of(R)),
+             md5 => md5(bin_of(R)),
+             clean_md5 => md5(bin_of(CleanR))},
+    io:format("  ~-7w clean ~7.1f s  runner ~8.1f MB  worker ~8.1f MB  ~s~n",
+              [Arm, CleanUs / 1000000, runner_peak(Row), worker_peak(Row),
+               note_of(Row)]),
+    Row.
+
+clean_only(Arm, Core, Live) ->
+    {CleanUs, CleanR} = clean(Arm, Core, Live),
+    Row = #{arm => Arm, clean_us => CleanUs,
+            bytes => byte_size(bin_of(CleanR)),
+            md5 => md5(bin_of(CleanR)),
+            clean_md5 => md5(bin_of(CleanR))},
+    io:format("  ~-7w clean ~7.1f s  (reversed order)~n",
+              [Arm, CleanUs / 1000000]),
+    Row.
+
+bin_of({ok, _Name, Bin}) -> Bin;
+bin_of(Other) -> erlang:error({compile_failed, Other}).
+
+md5(Bin) ->
+    {ok, {_Mod, MD5}} = beam_lib:md5(Bin),
+    MD5.
+
+%% Reported apart, because the whole finding this harness exists to test is that
+%% they are different numbers: `PERF.md' has 0.34 GB on the process `wasm_jit'
+%% spawns against 6.19 GB on the node. `runner' is the process holding the unit
+%% and waiting; `worker' is whatever actually ran the compiler, which is a child
+%% in two arms and the runner itself in the third.
+runner_peak(#{peaks := Peaks, runner := Runner}) ->
+    mb(map_get(Runner, Peaks)).
+
+worker_peak(#{peaks := Peaks, runner := Runner}) ->
+    case [V || {P, V} <- maps:to_list(Peaks), P =/= Runner] of
+        [] -> mb(map_get(Runner, Peaks));
+        Vs -> mb(lists:max(Vs))
+    end.
+
+mb(Words) -> Words * erlang:system_info(wordsize) / 1048576.
+
+note_of(#{per_pid := Per, runner := Runner}) ->
+    case [N || {P, #{note := N}} <- maps:to_list(Per), P =/= Runner] of
+        [] -> "one process";
+        Ns -> lists:flatten(io_lib:format("child ~w", [Ns]))
+    end.
+
+%%% -------------------------------------------------------------- report ---
+
+report(Rows, Funs, IrWords) ->
+    io:format("~n~-8s ~9s ~9s ~9s ~11s ~11s ~13s ~7s~n",
+              ["arm", "min s", "med s", "max s", "runner MB", "worker MB",
+               "alloc Mw", "colls"]),
+    Summ = [{A, summarise([R || R <- Rows, map_get(arm, R) =:= A])}
+            || A <- ?ARMS],
+    [io:format("~-8w ~9.1f ~9.1f ~9.1f ~11.1f ~11.1f ~13s ~7w~n",
+               [A, map_get(min, S), map_get(med, S), map_get(max, S),
+                map_get(runner, S), map_get(worker, S), alloc_str(S),
+                map_get(colls, S)])
+     || {A, S} <- Summ],
+    io:format("~nalloc Mw is the compiling process's own allocation. A `>'~n"
+              "is a floor: that arm's compiler is OTP's own child, which is~n"
+              "spawned inside `do_compile/2' and exits with its result, so~n"
+              "no closing collection can be forced and the final live set is~n"
+              "unmeasured. Never compare a floor against a closed window.~n"),
+    md5s(Rows),
+    spread(Summ),
+    ratio(Summ),
+    per_word(Summ, Funs, IrWords).
+
+summarise(Rows) ->
+    Ws = lists:sort([map_get(clean_us, R) / 1000000 || R <- Rows]),
+    %% Only the rows that carry a trace. A clean-only row has no memory in it
+    %% and must not be averaged in as a zero.
+    Ms = [R || R <- Rows, is_map_key(per_pid, R)],
+    #{min => hd(Ws),
+      med => lists:nth(1 + length(Ws) div 2, Ws),
+      max => lists:last(Ws),
+      runner => lists:max([runner_peak(R) || R <- Ms]),
+      worker => lists:max([worker_peak(R) || R <- Ms]),
+      alloc => biggest([worker_alloc(R) || R <- Ms]),
+      floor => biggest([worker_floor(R) || R <- Ms]),
+      colls => lists:sum([colls(R) || R <- Ms]) div length(Ms)}.
+
+%% `lists:max/1' is the wrong tool here and was the first version of it: an
+%% atom sorts above every number in Erlang term order, so one `undefined' in
+%% the list wins and a perfectly good measurement disappears.
+biggest(Vals) ->
+    case [V || V <- Vals, is_integer(V)] of
+        [] -> undefined;
+        Ns -> lists:max(Ns)
+    end.
+
+alloc_str(#{alloc := undefined, floor := undefined}) -> "none";
+alloc_str(#{alloc := undefined, floor := F}) ->
+    lists:flatten(io_lib:format("> ~.1f", [F / 1000000]));
+alloc_str(#{alloc := A}) ->
+    lists:flatten(io_lib:format("~.1f", [A / 1000000])).
+
+%% The process that ran the compiler, which is a child in two arms and the
+%% runner itself in the third, and only when its window is closed at both ends.
+worker_alloc(Row) -> from_worker(Row, allocated, complete).
+
+%% What the same process reclaimed, which is all an unbounded window can say.
+worker_floor(Row) -> from_worker(Row, reclaimed, lower).
+
+from_worker(#{per_pid := Per, runner := Runner}, Key, Note) ->
+    Ms = case [M || {P, M} <- maps:to_list(Per), P =/= Runner] of
+             [] -> [map_get(Runner, Per)];
+             Cs -> Cs
+         end,
+    biggest([maps:get(Key, M, undefined)
+             || M <- Ms, maps:get(note, M, none) =:= Note]).
+
+colls(#{per_pid := Per}) ->
+    lists:sum([maps:get(collections, M, 0) || M <- maps:values(Per)]).
+
+%% Same work, same output. The `no_spawn_compiler_process' atom lands in the
+%% `compile_info' chunk, so `inline' and `child' are a few bytes larger than
+%% `otp' and the md5 is identical for all three. An md5 that differs means the
+%% arms did not compile the same thing and no timing below means anything.
+md5s(Rows) ->
+    Set = lists:usort([map_get(md5, R) || R <- Rows] ++
+                      [map_get(clean_md5, R) || R <- Rows]),
+    Sizes = lists:usort([{map_get(arm, R), map_get(bytes, R)} || R <- Rows]),
+    io:format("~nmd5          ~s (~w distinct)~n",
+              [case Set of [_] -> "identical across every arm and run";
+                           _ -> "DIFFERENT, the arms did not do the same work"
+               end, length(Set)]),
+    io:format("bytes        ~p~n", [Sizes]).
+
+%% Before any of the numbers are read: an arm whose own samples disagree by
+%% more than a fifth is measuring the box, not the arm.
+spread([]) -> ok;
+spread(Summ) ->
+    Bad = [{A, Min, Max} || {A, #{min := Min, max := Max}} <- Summ,
+                            Min > 0, (Max - Min) / Min > 0.20],
+    case Bad of
+        [] -> io:format("spread       within 20% on every arm~n");
+        _ -> io:format("spread       TOO WIDE ~p, redo the run~n", [Bad])
+    end.
+
+%% The gate. One ordered rule on one ratio, from the clean walls, so no result
+%% matches two branches and none is unclassified.
+ratio(Summ) ->
+    {_, #{min := Otp}} = lists:keyfind(otp, 1, Summ),
+    {_, #{min := Child}} = lists:keyfind(child, 1, Summ),
+    R = Child / Otp,
+    io:format("~nR            ~.3f  (child min / otp min)~n", [R]),
+    io:format("verdict      ~s~n",
+              [if R =< 1.10 -> "R =< 1.10, the ceiling is free: ship it";
+                  R =< 1.20 -> "1.10 < R =< 1.20: ship opt-in, record the cost";
+                  true -> "R > 1.20: stop, record the second negative result"
+               end]).
+
+%% What `src/wasm_jit.erl' cites without a source. Only from an arm whose
+%% window is closed at both ends.
+per_word(Summ, Funs, IrWords) ->
+    case lists:keyfind(child, 1, Summ) of
+        {child, #{alloc := A}} when is_integer(A), IrWords > 0 ->
+            io:format("per IR word  ~.2f KB allocated in the compiler, over "
+                      "~w functions and ~w IR words~n",
+                      [A * erlang:system_info(wordsize) / IrWords / 1024,
+                       Funs, IrWords]);
+        _ ->
+            io:format("per IR word  not available: the child arm has no "
+                      "closed window~n")
+    end.
+
+%%% ------------------------------------------------------------- context ---
+
+where() ->
+    [io:format("~-12s ~s~n", [M, code:which(M)])
+     || M <- [wasm_core, wasm_jit, compile]],
+    io:format("~-12s ~s / erts ~s~n",
+              [otp, erlang:system_info(otp_release),
+               erlang:system_info(version)]).
+
+load() ->
+    string:trim(lists:last(string:split(os:cmd("uptime"), "average", trailing))).
+
+%%% ------------------------------------------------------------- proving ---
+
+-doc """
+Prove the pid-keyed estimator where `allocwords` cannot follow it.
+
+Two processes allocate a known amount at the same time, with their collections
+interleaved in one tracer mailbox. A list of N cons cells is 2N heap words, so
+each process's own figure has to come out at about 2N once the fixed per-process
+overhead is taken off. `allocwords:validate/0` proves the arithmetic; this
+proves that grouping by pid keeps it true when the events are interleaved,
+which is the only thing this module changed.
+""".
+-spec validate() -> ok | {error, term()}.
+validate() ->
+    Overhead = pair_alloc(0, 0),
+    io:format("harness overhead ~p words~n~n", [Overhead]),
+    io:format("~10s ~14s ~16s ~16s ~10s~n",
+              ["N", "want", "runner", "child", "worst"]),
+    Rows = [vrow(N, Overhead) || N <- [200000, 1000000, 3000000]],
+    io:format("~n"),
+    case [R || {_, _, _, _, E} = R <- Rows, E > 0.05] of
+        [] -> io:format("pid-keyed estimator agrees within 5%~n"), ok;
+        Bad -> io:format("pid-keyed estimator is wrong: ~p~n", [Bad]),
+               {error, Bad}
+    end.
+
+vrow(N, {ORunner, OChild}) ->
+    Want = 2 * N,
+    {Runner, Child} = pair_alloc(N, N),
+    R = Runner - ORunner,
+    C = Child - OChild,
+    Err = lists:max([abs(R - Want) / Want, abs(C - Want) / Want]),
+    io:format("~10w ~14w ~16w ~16w ~9.1f%~n", [N, Want, R, C, Err * 100]),
+    {N, Want, R, C, Err}.
+
+%% Both processes hold their list through their own closing collection, so both
+%% exercise the live-set half of the formula, and both collect while the other
+%% is collecting, which is the interleaving under test.
+pair_alloc(NRunner, NChild) ->
+    Owner = self(),
+    Runner =
+        spawn(fun () ->
+                  receive go -> ok end,
+                  erlang:garbage_collect(),
+                  Me = self(),
+                  _ = spawn(fun () ->
+                                  erlang:garbage_collect(),
+                                  L = lists:duplicate(NChild, 0),
+                                  erlang:garbage_collect(),
+                                  Me ! {kid, self(), length(L)}
+                              end),
+                  Mine = lists:duplicate(NRunner, 0),
+                  KidPid = receive {kid, K, _} -> K end,
+                  erlang:garbage_collect(),
+                  Owner ! {done, self(), length(Mine), [KidPid]}
+              end),
+    1 = erlang:trace(Runner, true, ?FLAGS),
+    Runner ! go,
+    #{runner := R, per_pid := Per} = watch(Runner, #{Runner => 0}, [], 0),
+    Others = [M || {P, M} <- maps:to_list(Per), P =/= R],
+    {maps:get(allocated, map_get(R, Per), 0),
+     lists:max([maps:get(allocated, M, 0) || M <- Others] ++ [0])}.

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -116,7 +116,8 @@ to a bounded shape and the last few dozen are kept.
 
 **Every refusal means interpret**, and none of them is an error: a function
 outside the subset, a slot pool with nothing free, another process already
-compiling the same module, a finite fuel budget, or a compile failure.
+compiling the same module, a finite fuel budget, a compile failure, or a
+compiler over its heap ceiling.
 
 **Metered execution is interpreted.** Fuel is charged at every loop back edge,
 and charging it round a compiled loop gives back what compiling it bought, so an
@@ -152,6 +153,39 @@ application:set_env(wasm, code_cache_dir, "/var/cache/my_app/wasm").
 
 QuickJS then takes 0.2 seconds instead of 43.7 on the second start.
 
+## Bound what a compile may spend
+
+The runtime runs `compile:forms/2` in a process it spawns itself, so a heap
+ceiling can be put on the process that actually does the work:
+
+```erlang
+application:set_env(wasm, compile_max_heap_words, 2_000_000_000).
+```
+
+A compile over it is killed and **refused**, which means the guest interprets
+and answers exactly as before, and `wasm_jit:diagnostics/0` says
+`{limit, {compile_memory, Words}}`. Ask what is in force with
+`wasm_jit:compile_limits/0`, which reports `max_heap_words => 0` when there is
+none.
+
+**Off by default**, because there is no number that is right for every guest:
+QuickJS's compiler peaks around 2.5 GB, CPython's whole-module compile reached
+33 GB, and CPython's *legitimate* 2,333-function compile sits between them, so
+a ceiling low enough to catch the second refuses the third. Set it from a
+measurement of your own module, and set it before you use `compile_whole` on a
+large guest.
+
+Three things it does not bound, and it is a ceiling rather than a guarantee:
+Core generation, which happens on the calling process before the compiler is
+spawned; anything that is not process heap, such as allocator memory and node
+RSS; and the sum across concurrent compiles, since sixteen compilers may each
+sit under it. `max_heap_size` is also checked only when a garbage collection
+runs, so a compile can overshoot between collections.
+
+A value that is not a whole number of words between `min_heap_size` and
+`(1 bsl 59) - 1` is reported once through `logger` and ignored, rather than
+turning the tier off for the life of the node.
+
 **Off by default, and the directory is as trusted as your release.** Loading a
 `.beam` from it executes whatever is in that file, so it must not be writable by
 anything you would not run as code.
@@ -165,7 +199,7 @@ validated, so there is nothing stable to key on.
 | module | decides |
 | --- | --- |
 | `wasm_jit` | when a module gets compiled and how a call reaches the result. Policy only. |
-| `wasm_core` | what Core Erlang a function lowers to, and which functions it will take at all. |
+| `wasm_core` | what Core Erlang a function lowers to, which functions it will take at all, and the process the OTP compiler runs in. |
 | `wasm_code_slots` | which of sixteen module names the result may load into, and when that name may be reused. |
 | `wasm_code_cache` | whether an artifact already exists on disk. |
 | `wasm_jit_sup` | the processes that compile, so none of them is invisible. |

--- a/src/wasm_code_slots.erl
+++ b/src/wasm_code_slots.erl
@@ -106,6 +106,7 @@ reasoning.
 -export([lease_call/1, lease_call/2, release_call/1, calls_in/1]).
 -export([hot/2]).
 -export([record_diagnostic/4, diagnostics/0, clear_diagnostics/0]).
+-export([observe_config/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -export_type([key/0, lease/0, token/0]).
@@ -185,7 +186,11 @@ reasoning.
 %% out of the pool for good, so its `DOWN' aborts the reservation.
 -record(state, {monitors = #{} :: #{reference() => {key(), lease()}},
                 refs     = #{} :: #{{key(), lease()} => reference()},
-                loading  = #{} :: #{reference() => token()}}).
+                loading  = #{} :: #{reference() => token()},
+                %% The bad `compile_max_heap_words' currently in force, if any.
+                %% One entry and not a set: a set would retain every value
+                %% anyone ever mistyped for the life of the node.
+                bad_cfg  = ok   :: ok | {bad, term()}}).
 
 %%% ----------------------------------------------------------------- api ---
 
@@ -259,6 +264,37 @@ diagnostics() ->
     case ets:whereis(?DIAG) of
         undefined -> [];
         _ -> [{O, K, R} || {_Seq, O, K, R, _At} <- ets:tab2list(?DIAG)]
+    end.
+
+-doc """
+Say what resolving `compile_max_heap_words` produced, and warn once if it is bad.
+
+Told about **every** resolution and not only the failures. Without the good
+ones, a value that is bad, then corrected, then mistyped the same way again
+would stay silent the second time, because nothing would have told this server
+the condition had cleared.
+
+The warning is emitted *here*, inside the call, rather than by a caller acting
+on a `first` reply: a caller can die between the reply and the `logger` call,
+and this server would then be holding a value it believes was reported and
+nobody ever saw. Exactly-once needs the decision and the saying to be the same
+serialised step.
+
+So: **once per uninterrupted occurrence of the same bad value.** Bad A three
+times warns once; bad A, valid, bad A warns twice; bad A then bad B warns twice.
+A manager restart re-arms it, since the held value lives in `#state{}`, and that
+is right: a restarted manager has not complained about anything.
+
+Deliberately not a diagnostics-ring row. The ring's sixty-four entries answer
+"why did the last compiles that did not happen not happen", and a mistyped
+environment key is not a compile that did not happen. Spending rows on it would
+evict real refusals.
+""".
+-spec observe_config(ok | {bad, term()}) -> ok.
+observe_config(What) ->
+    case whereis(?MODULE) of
+        undefined -> ok;
+        _ -> gen_server:call(?MODULE, {observe_config, What})
     end.
 
 -doc "Forget them. The caller's sequence is deliberately not reset with them.".
@@ -540,6 +576,16 @@ init([]) ->
      end || {N, G, {loading, _}, _} <- ets:tab2list(?TAB)],
     {ok, #state{monitors = Ms, refs = Rs}}.
 
+handle_call({observe_config, Same}, _From, #state{bad_cfg = Same} = S) ->
+    {reply, ok, S};
+handle_call({observe_config, ok}, _From, S) ->
+    {reply, ok, S#state{bad_cfg = ok}};
+handle_call({observe_config, {bad, Raw}}, _From, S) ->
+    {min_heap_size, Min} = erlang:system_info(min_heap_size),
+    logger:warning("wasm: compile_max_heap_words is ~p, which is not a whole "
+                   "number of words between ~p and ~p; compiling with no heap "
+                   "ceiling", [Raw, Min, (1 bsl 59) - 1]),
+    {reply, ok, S#state{bad_cfg = {bad, Raw}}};
 handle_call({claim_loading, Key, Lease, Owner}, _From, S) ->
     case find(Key) of
         %% Somebody else is filling this in. Interpret rather than wait.

--- a/src/wasm_core.erl
+++ b/src/wasm_core.erl
@@ -44,8 +44,9 @@ every other refusal here: interpret it.
 
 -export([fun_name/1, frame_name/1, limits/0, atoms/0]).
 -export([supported/1, can_compile/2, ops/0, module/4, module/6]).
--export([module/7, module/8, module/9]).
+-export([module/7, module/8, module/9, module/10]).
 -export([forms/5, forms/6, forms/7, forms/8]).
+-export([reap/2]).
 
 -include("wasm_exec.hrl").
 -include("wasm_memory.hrl").
@@ -448,14 +449,128 @@ As `module/8`, saying which other unit holds each function this one does not.
              #{non_neg_integer() => module()}) ->
           {ok, binary()} | {error, term()}.
 module(Name, Unit, Sigs, TSigs, Mode, Stamp, Next, Head, Elsewhere) ->
+    module(Name, Unit, Sigs, TSigs, Mode, Stamp, Next, Head, Elsewhere, #{}).
+
+-doc """
+As `module/9`, bounding the heap of the process that runs the OTP compiler.
+
+`Opts` takes `max_heap_words`, and a unit whose compiler exceeds it answers
+`{error, {limit, {compile_memory, Words}}}` rather than dying. Absent means no
+ceiling, which is the default and what every caller but `wasm_jit` passes.
+""".
+-spec module(module(), [term()], map(), map(), baseline | full,
+             binary() | non_neg_integer(), undefined | module(), module(),
+             #{non_neg_integer() => module()},
+             #{max_heap_words => pos_integer()}) ->
+          {ok, binary()} | {error, term()}.
+module(Name, Unit, Sigs, TSigs, Mode, Stamp, Next, Head, Elsewhere, Opts) ->
     case forms(Name, Unit, Sigs, TSigs, Stamp, Next, Head, Elsewhere) of
-        {ok, Core} ->
-            case compile:forms(Core, copts(Mode)) of
-                {ok, Name, Bin} -> {ok, Bin};
-                {error, Es, _Ws} -> {error, {compile, Es}}
-            end;
+        {ok, Core} -> run_compiler(Name, Core, copts(Mode), Opts);
         {error, _} = E -> E
     end.
+
+-doc """
+Run the OTP compiler in a process this runtime owns.
+
+`compile:forms/2` runs its passes in a process of its own and gives a caller no
+way to configure it, so a `max_heap_size` set on the process `wasm_jit` spawns
+bounds a process that only waits: 141 MB watched against 2,055 MB spent, in
+`test/audit/PERF.md`. `no_spawn_compiler_process` declines that spawn, and this
+makes the same one with our options on it.
+
+The child is short-lived by construction, exactly as OTP's own is: it allocates,
+answers and exits, so it never pays for a collection of what it built. That is
+why this is free, measured at 0.9% over five interleaved samples.
+
+Two things follow from owning it rather than OTP:
+
+- **a ceiling can be set**, which is the point;
+- **it can be stopped.** `spawn_monitor/1` does not link, so OTP's child
+  outlives the process that asked for it: today a compiler killed by
+  `wasm_jit_sup`'s `brutal_kill`, or by `application:stop(wasm)`, leaves the
+  OTP compiler running to completion holding its copy of the forms, with
+  nothing in the tree able to see it. `reap/2` closes that.
+""".
+run_compiler(Name, Core, Copts, Opts) ->
+    Owner = self(),
+    {Pid, Ref} = spawn_opt(fun () -> compiler(Owner, Core, Copts) end,
+                           [monitor | heap_opts(Opts)]),
+    receive
+        {compiled, Pid, R} ->
+            demonitor(Ref, [flush]),
+            unwrap(Name, R);
+        %% `killed' says the process was killed and not why. Its pid is
+        %% published nowhere and the only kill this module issues comes from
+        %% `reap/2', which fires solely when the owner is already dead and so
+        %% has nobody left to hear an answer. A `killed' seen by a live owner
+        %% is the ceiling, unless a third party is killing pids it did not
+        %% spawn.
+        {'DOWN', Ref, process, Pid, killed} ->
+            {error, {limit, {compile_memory, maps:get(max_heap_words, Opts, 0)}}};
+        {'DOWN', Ref, process, Pid, Why} ->
+            {error, {compiler_died, Why}}
+    end.
+
+%% By message rather than by exit reason, which is how OTP returns it. The
+%% artifact is a refcounted binary, so either way what crosses is a header, and
+%% a message leaves the child exiting `normal'.
+compiler(Owner, Core, Copts) ->
+    %% Bound out here. Inside the fun, `self()` is the *reaper's* pid, so the
+    %% reaper would watch itself, kill itself when the owner died, and leave the
+    %% compiler it exists to stop running to completion.
+    Me = self(),
+    _ = spawn(fun () -> reap(Owner, Me) end),
+    Owner ! {compiled, Me, compile:forms(Core, [no_spawn_compiler_process |
+                                                Copts])},
+    ok.
+
+-doc """
+Kill `Child` if `Owner` dies first, and stop as soon as either does.
+
+Exported for `wasm_jit:pmap/2`, which has the same problem one rung up: its
+shard workers are spawned monitored and unlinked, so a killed coordinator would
+leave them compiling toward slots nobody owns.
+""".
+-spec reap(pid(), pid()) -> ok | true.
+%% Spawned *by the child*, which is what makes it window-free: if the owner is
+%% already gone, `monitor/2` answers `noproc` at once and the child is killed
+%% before it has compiled anything. Spawned by the owner there would be a gap
+%% between having the child's pid and telling the reaper about it.
+%%
+%% Not a link, which cannot be used here: a `max_heap_size` kill exits the child
+%% with reason `killed`, and an untrapping owner linked to it dies with `killed`
+%% too, before it can record the outcome. The owner under `compile_sync` is the
+%% embedder's own process and is not ours to kill or to set flags on.
+reap(Owner, Child) ->
+    OwnerRef = monitor(process, Owner),
+    ChildRef = monitor(process, Child),
+    receive
+        {'DOWN', ChildRef, process, Child, _} -> ok;
+        %% `exit/2` on a pid that has already gone is `true`, so losing this
+        %% race costs nothing.
+        {'DOWN', OwnerRef, process, Owner, _} -> exit(Child, kill)
+    end.
+
+%% `kill` and `error_logger` are set rather than inherited: `+hmaxk false`
+%% node-wide would otherwise turn the ceiling into a suggestion, and the outcome
+%% is already recorded as a value on a counter and in the diagnostics ring, so a
+%% `logger` event beside it is duplicate noise.
+%%
+%% `include_shared_binaries` counts the artifact itself, which is 7 MB for a
+%% QuickJS unit and 80 MB for CPython's, against a working set measured in
+%% gigabytes. Conservative, and noise beside what it is bounding.
+heap_opts(#{max_heap_words := W}) when is_integer(W), W > 0 ->
+    [{max_heap_size, #{size => W, kill => true, error_logger => false,
+                       include_shared_binaries => true}}];
+heap_opts(_) ->
+    [].
+
+%% `compile:forms/2` answers its child's exit reason, so a compiler that died
+%% rather than returning arrives here as an arbitrary term. Matching only the
+%% two documented shapes made that a `case_clause`.
+unwrap(Name, {ok, Name, Bin}) -> {ok, Bin};
+unwrap(_Name, {error, Es, _Ws}) -> {error, {compile, Es}};
+unwrap(_Name, Other) -> {error, {compiler_died, {unexpected, Other}}}.
 
 -doc """
 The Core Erlang this unit lowers to, before the OTP compiler sees it.

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -18,8 +18,9 @@ while a generated loop runs.
 ## Every failure interprets
 
 A module the generator refuses, a slot pool that is exhausted, another process
-already compiling the same module, a finite fuel budget, a compile error: all
-of them mean run the interpreter, and none of them is an error. That is what
+already compiling the same module, a finite fuel budget, a compile error, a
+compiler over `compile_max_heap_words`: all of them mean run the interpreter,
+and none of them is an error. That is what
 makes the tier safe to enable at all, and it is also what makes a green test
 run prove nothing on its own -- see `counts/0` and the `compile_force` option,
 which exist so that a conformance run can say generated code actually ran.
@@ -55,7 +56,7 @@ moved, because even with all three a refusal still interprets.
 
 -export([entry/3, after_call/2, counts/0, reset_counts/0, await/2, release/1]).
 -export([diagnostics/0, normalize_reason/1, shard_count/2, shards/1]).
--export([compile_limits/0]).
+-export([compile_limits/0, max_heap_words/0]).
 -export([reentered/0]).
 -export([compiler_loop/0]).
 -export([dump/1, dump/2]).
@@ -97,6 +98,13 @@ moved, because even with all three a refusal still interprets.
 %% small: CPython's accepted hot set is 3.7 M words and peaked at 59.89 GB, so a
 %% ceiling admitting today's ordinary path would protect nothing.
 -define(MAX_COMPILE_FUNS, 8192).
+
+%% The largest `max_heap_size` `size` a 64-bit emulator accepts. Undocumented,
+%% and a hard edge rather than a soft one: measured on OTP 29, `1 bsl 59` raises
+%% `badarg` from `spawn_opt` and `(1 bsl 59) - 1` does not. An operator who
+%% writes a plausible-looking very large number gets a warning rather than a
+%% compiler that cannot start.
+-define(MAX_HEAP_WORDS, ((1 bsl 59) - 1)).
 %% Set by `entry_1/3` when this call found the module hot and unbuilt, read by
 %% `after_call/2` once the call has finished. The invocation's own lifetime is
 %% exactly the right one for it, which is the same argument the checkpoint key
@@ -719,6 +727,18 @@ generate_1(Inst, Limits, Mod, Token, Unit) ->
             %% It still costs 129.3 seconds against 58.1 to compile the hot set,
             %% and that is what `compile_shards` is for.
             Mode = maps:get(compile_quality, Limits, full),
+            %% The one place the ceiling is read, and provably one: `compile/4`
+            %% reaches `generate/5` only in `generate` mode, `generate/5`
+            %% reaches here unconditionally, and the two `adopt`-mode callers
+            %% never generate. The resolved map travels into `pmap/2`'s closure,
+            %% so a shard worker inherits it rather than reading the
+            %% environment on a process that has no business doing so.
+            {Words, Config} = resolve_max_heap_words(),
+            ok = wasm_code_slots:observe_config(Config),
+            COpts = case Words of
+                        0 -> #{};
+                        _ -> #{max_heap_words => Words}
+                    end,
             {_Name, Gen} = Token,
             Stamp = stamp(Inst, Gen),
             case split(Unit, Limits) of
@@ -728,7 +748,8 @@ generate_1(Inst, Limits, Mod, Token, Unit) ->
                     ok = wasm_code_slots:abort(Token),
                     {refused, {limit, {too_many_functions, N}}};
                 Parts ->
-                    build(Inst, Limits, Mode, Stamp, Unit, Parts, [{Mod, Token}])
+                    build(Inst, Limits, Mode, Stamp, Unit, Parts,
+                          [{Mod, Token}], COpts)
             end
     end.
 
@@ -740,8 +761,8 @@ generate_1(Inst, Limits, Mod, Token, Unit) ->
 %% used sooner, because the functions worth compiling are the ones expensive to
 %% compile: sixteen of QuickJS's hot functions are already 30 seconds of the 54.
 %% See `test/audit/PERF.md`.
-build(Inst, _Limits, Mode, Stamp, Unit, [_], [{Mod, Token}]) ->
-    case artifact(Inst, Mod, Unit, Mode, Stamp, undefined, Mod, #{}) of
+build(Inst, _Limits, Mode, Stamp, Unit, [_], [{Mod, Token}], COpts) ->
+    case artifact(Inst, Mod, Unit, Mode, Stamp, undefined, Mod, #{}, COpts) of
         {ok, Bin} ->
             {module, Mod} = code:load_binary(Mod, "wasm_generated", Bin),
             ok = wasm_code_slots:publish(Token),
@@ -751,7 +772,7 @@ build(Inst, _Limits, Mode, Stamp, Unit, [_], [{Mod, Token}]) ->
             ok = wasm_code_slots:abort(Token),
             outcome(Reason)
     end;
-build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First]) ->
+build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First], COpts) ->
     %% Every slot claimed before anything is generated, because each unit names
     %% the next as a literal and cannot be built until that name exists. This
     %% process owns all of them, so a compiler that dies takes every reservation
@@ -773,7 +794,7 @@ build(Inst, Limits, Mode, Stamp, _Unit, Parts, [First]) ->
             Bins = pmap(fun({U, M, Next}) ->
                             Mine = [Idx || {_, Idx, _, _} <- U],
                             artifact(Inst, M, U, Mode, Stamp, Next, Head,
-                                     maps:without(Mine, Where))
+                                     maps:without(Mine, Where), COpts)
                         end, Jobs),
             publish_all(Inst, Limits, Tokens, Parts, Bins)
     end.
@@ -835,9 +856,43 @@ Every bound the compiled tier applies to a *request*, so a caller can ask rather
 than infer it from a refusal. `wasm_core:limits/0` is the same idea for the
 bounds a single unit has.
 """.
--spec compile_limits() -> #{atom() => pos_integer()}.
+%% `non_neg_integer()`, because `max_heap_words` answers 0 for "no ceiling",
+%% which is `max_heap_size`'s own meaning for a size of zero.
+-spec compile_limits() -> #{atom() => non_neg_integer()}.
 compile_limits() ->
-    #{max_compile_funs => ?MAX_COMPILE_FUNS, max_shards => ?MAX_SHARDS}.
+    #{max_compile_funs => ?MAX_COMPILE_FUNS, max_shards => ?MAX_SHARDS,
+      max_heap_words => max_heap_words()}.
+
+-doc """
+The heap ceiling a compile would be given, in words, or 0 for none.
+
+Reads `compile_max_heap_words` and reports the *effective* value, so a caller is
+told what the tier would actually apply rather than what the code defaults to.
+Asking never reports: it does not log, move a counter, or clear what
+`wasm_code_slots` is holding, because a question must not have the side effects
+of a compile.
+""".
+-spec max_heap_words() -> non_neg_integer().
+max_heap_words() -> element(1, resolve_max_heap_words()).
+
+%% Answers the effective value *and* what to say about it, because the two
+%% cannot be recovered from one another: a bad value and an absent one both
+%% resolve to 0, and the raw term is what deduplicates the warning.
+%%
+%% `min_heap_size` is a *tuple*, `{min_heap_size, 233}` on OTP 29, so comparing
+%% an integer against it directly rejects every integer there is. The upper
+%% bound is undocumented and just as real: `size` must be a small integer, and
+%% `spawn_opt` raises `badarg` at `1 bsl 59` exactly as it does below the
+%% minimum.
+-spec resolve_max_heap_words() -> {non_neg_integer(), ok | {bad, term()}}.
+resolve_max_heap_words() ->
+    {min_heap_size, Min} = erlang:system_info(min_heap_size),
+    case application:get_env(wasm, compile_max_heap_words, undefined) of
+        undefined -> {0, ok};
+        0 -> {0, ok};
+        W when is_integer(W), W >= Min, W =< ?MAX_HEAP_WORDS -> {W, ok};
+        Bad -> {0, {bad, Bad}}
+    end.
 
 -doc """
 How many units this many functions are split into.
@@ -962,11 +1017,23 @@ claim_rest(Inst, N, Acc) ->
 
 %% Run the units at once. `compile:forms/2` is the whole of the cost and the
 %% units share nothing, so this is the wall clock the split is for.
+%% Each worker reaps against this process, for the same reason `wasm_core` does
+%% one rung further down: `spawn_monitor/1` does not link, so a coordinator that
+%% is killed leaves its shard workers running, holding their copied units and
+%% compiling toward slots nobody owns. A link would be the ordinary answer and
+%% cannot be used, because a worker killed by the heap ceiling exits `killed`
+%% and would take this untrapping process with it before `collect/1` could
+%% record anything.
 pmap(F, Xs) ->
     Parent = self(),
-    Pids = [element(1, spawn_monitor(fun() -> Parent ! {self(), F(X)} end))
+    Pids = [element(1, spawn_monitor(fun() -> reaped(Parent, F, X) end))
             || X <- Xs],
     [collect(P) || P <- Pids].
+
+reaped(Parent, F, X) ->
+    Me = self(),
+    _ = spawn(fun() -> wasm_core:reap(Parent, Me) end),
+    Parent ! {Me, F(X)}.
 
 collect(Pid) ->
     receive
@@ -983,7 +1050,7 @@ collect(Pid) ->
 %% today's instance. What it *does* depend on is the slot, because a module's
 %% name is part of its BEAM file, which is why the slot is in the key and why
 %% `wasm_code_slots` prefers a module's own slot when one is free.
-artifact(Inst, Mod, Unit, Mode, Stamp, Next, Head, Elsewhere) ->
+artifact(Inst, Mod, Unit, Mode, Stamp, Next, Head, Elsewhere, COpts) ->
     %% Not cached when it is one of several. The key would have to carry which
     %% module the chain points at next, and a shard set is only reproducible if
     %% the same split falls out of the same workload, which nothing promises.
@@ -999,7 +1066,7 @@ artifact(Inst, Mod, Unit, Mode, Stamp, Next, Head, Elsewhere) ->
         {ok, Bin} -> bump(?IX_CACHED, 1), {ok, Bin};
         _ ->
             case wasm_core:module(Mod, Unit, sigs(Inst), tsigs(Inst), Mode,
-                                  Stamp, Next, Head, Elsewhere) of
+                                  Stamp, Next, Head, Elsewhere, COpts) of
                 {ok, Bin} = Ok ->
                     Key =:= undefined orelse wasm_code_cache:store(Key, Bin),
                     Ok;

--- a/src/wasm_jit_sup.erl
+++ b/src/wasm_jit_sup.erl
@@ -32,6 +32,27 @@ released by `wasm_code_slots`'s monitor when it dies, and the instance's own
 record of having asked expires on its own, so being killed at any moment costs
 nothing but the work.
 
+## The two processes per compile that are not in this tree
+
+`wasm_core:run_compiler/4` spawns the process that runs `compile:forms/2`, and
+that process spawns a reaper. Neither is supervised, which this doc says
+elsewhere is a place where nothing can see, bound or stop a process, so the
+exception is worth stating.
+
+They are bounded by the sixteen slot reservations rather than by any count of
+compilers: a compiler that cannot claim a slot gives up at once, and a unit
+being built holds one. So at most sixteen units are in flight, and a sharded one
+carries four such processes rather than two, since each `pmap` worker has a
+reaper of its own. The `count_children/1` check below is *not* the bound; it is
+soft and racy by design.
+
+And they are stoppable, which is the point of the reaper and is more than can be
+said for what they replace. `compile:forms/2` spawns its worker with
+`spawn_monitor/1`, which does not link, so before this the OTP compiler outlived
+the process that asked for it: a child killed here, or by `application:stop/1`,
+left a compiler running to completion holding its copy of the forms with nothing
+able to see it.
+
 ## Why the bound is not a supervisor flag
 
 An OTP supervisor has no `max_children`; that belongs to pool libraries. The

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4530,3 +4530,56 @@ error, and the next person to instrument a compile will meet them again.
 allocation in two processes at once, which `allocwords` cannot do because its
 own arithmetic assumes the events it pairs come from one process. It agrees to
 0.0% at 200 K, 1 M and 3 M words. Run it before believing anything above.
+
+### What shipped, and the decision the gate made for us
+
+`R = 1.009` fell in the plan's `=< 1.10` branch, which had been written to mean
+**own the compiler worker unconditionally** rather than only when a ceiling is
+configured. So that is what shipped, and the argument is not the ceiling:
+
+| | conditional | unconditional |
+| --- | --- | --- |
+| ceiling reaches the compiler | when configured | when configured |
+| a killed compiler stops OTP's | only when configured | **always** |
+| artifact bytes vs the parent | identical when off | 60 bytes, `md5` identical |
+| topologies to reason about | two | one |
+
+The orphan is the reason. `compile:forms/2` spawns with `spawn_monitor/1`,
+which monitors and does not link, so on the parent commit a compiler killed by
+`wasm_jit_sup`'s `brutal_kill` or by `application:stop(wasm)` leaves the OTP
+compiler running to completion, holding its own copy of the forms, with nothing
+in the tree able to see or stop it. Measured directly: a caller killed 400 ms
+into a compile leaves its child alive, and the child is still alive three
+seconds later. Making that conditional on an opt-in ceiling would have left the
+default path with a defect for no reason but a promise about byte-identical
+artifacts, and the artifacts are `beam_lib:md5`-identical anyway.
+
+`compile_max_heap_words` stays **off by default**. There is still no defensible
+number: the only bracket is QuickJS's 2.5 GB worker against CPython's 33 GB
+pathology, with CPython's *legitimate* 2,333-function compile somewhere between
+them, and a ceiling low enough to catch the second would refuse the third.
+`kill => true` is destructive and belongs to the embedder.
+
+### The orphan case is the fourth vacuous test this project has caught
+
+It passed on the parent commit three times, for three different reasons, before
+it was made to fail there. Recorded because every one of them is a way to write
+a lifetime test that proves nothing.
+
+1. **It failed on the parent for the wrong reason**: `undef` on a helper calling
+   `wasm_code_slots:observe_config/1`, which the parent does not have. A failure
+   in the harness looks exactly like a failure in the runtime.
+2. **It found our own coordinator instead of OTP's child.** A process *waiting*
+   in `compile:do_compile/2`'s receive has `compile` frames in its stacktrace
+   just as the process doing the work does. Killing the coordinator then
+   satisfied "no compiler is running".
+3. **The detector flickered.** Testing "is any process currently inside the
+   compiler" samples a stacktrace against a handful of module names, and a
+   compiler moves between passes constantly. A live orphan read as present, and
+   one millisecond later as gone. The fix is to catch the pid once and then ask
+   `is_process_alive/1`, which has no such gap.
+
+And a fourth, in the fix rather than the test: the reaper was spawned as
+`spawn(fun () -> reap(Owner, self()) end)`, where `self()` is the *reaper's* pid.
+It monitored itself, killed itself when the owner died, and left the compiler it
+exists to stop running to completion. The case caught it.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4419,3 +4419,114 @@ of a cached module ever matters.
 `-spec await(#inst{}, timeout())` and computes
 `erlang:monotonic_time(millisecond) + Timeout`, so the `infinity` its own spec
 admits is a `badarith`. Identical on `origin/main`; it predates this branch.
+
+## Owning the compiler worker: the ceiling is free, and the row that killed it does not reproduce
+
+The section above closed with "neither ships", on two measurements: a
+`max_heap_size` ceiling on the process `wasm_jit` spawns sees 0.34 GB of a
+compile whose node reaches 6.19 GB, and `no_spawn_compiler_process` on that same
+coordinator costs 293 s against 167. The first says the ceiling cannot reach the
+work. The second says the only option that moves the work is too expensive.
+
+**Neither experiment tried the third shape**: `no_spawn_compiler_process` in a
+*fresh, disposable* process of our own, which is the lifecycle OTP's own child
+already has. `bench/paths/compileheap.erl` is that arm, beside the other two.
+
+QuickJS, one unit of 10 functions, 385,428 IR words, 17.2 M Core words, `full`,
+five samples per arm interleaved in both orderings, load 2.0 to 5.2 throughout,
+spread within 20% on every arm. Wall times are from a **second, untraced** run
+of each arm, because tracing charges the arms unequally.
+
+| arm | min s | med s | max s | runner MB | worker MB | alloc Mw |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `otp`, as called today | 70.4 | 72.0 | 76.6 | 169.2 | **2054.8** | > 14559.4 |
+| `inline`, on the coordinator | 71.8 | 72.7 | 77.2 | 2102.7 | 2102.7 | 14542.4 |
+| `child`, a fresh capped process | 71.0 | 71.6 | 74.6 | **141.0** | 2467.8 | 14542.4 |
+
+`beam_lib:md5/1` is identical across all thirty compiles, so the arms did the
+same work. The `otp` artifact is 60 bytes smaller than the other two, which is
+`no_spawn_compiler_process` landing in the `compile_info` chunk's option list.
+
+**The ceiling costs 0.9%.** `R = child min / otp min = 1.009`, against a gate of
+1.10 written before the numbers arrived.
+
+**The 0.34 GB finding reproduces exactly, at a tenth the scale.** A ceiling on
+the process `wasm_jit` spawns would watch **141 MB while the compiler spends
+2,055 MB**: 6.9%, against the 5.5% the 0.34 / 6.19 GB row records. That is the
+whole argument for owning the spawn, and it is not an argument about a number.
+
+### The 293-second row does not reproduce, and that matters more
+
+`inline` is **71.8 s against `otp`'s 70.4**, a 2% difference where
+`ATTEMPTS.md` records 75%. This is not the earlier measurement repeated with a
+smaller unit and a shrug: the runner in this arm holds the `#inst{}` and the
+whole unit IR live across the compile, which is precisely the condition the
+larger live set was supposed to explain, and it still costs 2%.
+
+So the plan that produced this harness was **right in its conclusion and wrong
+in its mechanism**. It predicted the +75% came from collecting the coordinator's
+live set on every pass, and that a fresh child would avoid it. The child is
+indeed free, but so is the coordinator, so the live set was never the cause.
+What produced 293 s against 167 s on that day is unexplained and is now the
+open question rather than the closed one.
+
+Two things follow, and the second is the one to act on. `no_spawn_compiler_process`
+carries no intrinsic penalty on this box at this scale, so the option is not the
+obstacle it was recorded as being. And the earlier row should be re-run at its
+own scale before anyone leans on it again: it is the single measurement standing
+between this project and a bounded compile, and it is now the least reproducible
+thing in this file.
+
+### What the arms cost to instrument, and what they cannot say
+
+`alloc Mw` is the compiling process's own allocation, from its own collection
+trace, over a window a forced major collection closes at each end. **The `otp`
+arm cannot have that window**, marked `>`: its compiler is spawned inside
+`compile:do_compile/2` and exits with its result, so no closing collection can
+be forced and the final live set is unmeasured. The figure is the reclaimed sum
+alone and is a floor. `inline` and `child` agree to five digits, 14,542.4 Mw,
+which is the estimator agreeing with itself across two different process
+topologies.
+
+**294.77 KB allocated per IR word**, over 385,428 words. `src/wasm_jit.erl:95-98`
+asserts "11 to 17 KB of allocated peak per IR word on both guests" and cites
+nothing, and that figure appears nowhere under `test/audit/`. These are not the
+same quantity: this one is total allocation over a whole compile, the comment's
+is a peak. Recorded here so the comparison exists; the comment still has no
+source and should get one or lose the number.
+
+Peaks are **sampled at 50 ms and are lower bounds**, always: a peak between two
+samples is invisible, and so is the memory the collector needs while collecting.
+Nothing here sizes a ceiling by them.
+
+### Six ways to measure this wrong, all of them found the hard way
+
+Recorded because each one produced a plausible, wrong number rather than an
+error, and the next person to instrument a compile will meet them again.
+
+- **`erlang:monotonic_time/1` is negative.** It reads about
+  -576,460,751,902 ms on this box, so a sampler seeded at `0` finds
+  `Now - Last >= 50` false for the next eighteen thousand years. Every peak
+  reads 0.0 MB and the run otherwise looks perfect.
+- **A sampler driven by `after` starves exactly where the peak is.** A compile
+  floods the tracer's mailbox, every message matches a clause, and the timeout
+  never fires while the compile is busiest. Drive it from the clock.
+- **`[procs, set_on_spawn]` delivers zero collection events.** A child inherits
+  only the flags its parent carries, so the trace needs
+  `garbage_collection` too, and `monotonic_timestamp` for the collection time.
+- **`monotonic_timestamp` renames the messages.** They become `trace_ts` with a
+  timestamp appended, so a spawn is a six-tuple. A harness matching
+  `{trace, ...}` matches nothing and silently discovers no compiler.
+- **`lists:max([N, undefined])` is `undefined`.** Atoms sort above numbers, so
+  one absent measurement discards every present one.
+- **`erts_debug:flat_size(Unit)` is not the IR size.** A unit entry carries the
+  whole `#fn{}` beside its IR, so budgeting on one and reporting the other
+  selected four times the unit it meant to. QuickJS's first eligible function
+  alone is 98,191 IR words and 4.4 M words of Core, and its first 402 functions
+  by index carry 8.07 M of the module's 12.0 M: function count is the wrong
+  handle on a compile whose functions differ by three orders of magnitude.
+
+`compileheap:main("validate")` proves the pid-keyed estimator against a known
+allocation in two processes at once, which `allocwords` cannot do because its
+own arithmetic assumes the events it pairs come from one process. It agrees to
+0.0% at 200 K, 1 M and 3 M words. Run it before believing anything above.

--- a/test/wasm_core_SUITE.erl
+++ b/test/wasm_core_SUITE.erl
@@ -691,7 +691,23 @@ the_core_you_can_read_is_the_core_that_is_compiled(_) ->
     {ok, Direct, Bin1} = compile:forms(Core, [from_core, binary, return_errors]),
     ?assertEqual(wasm_code_0, Direct),
     {ok, Bin2} = wasm_core:module(wasm_code_0, Unit, Sigs, TSigs, full, 0),
-    ?assertEqual(Bin2, Bin1),
+
+    %% On the *code*, not on the bytes. `module/6` runs the compiler in a
+    %% process it spawns itself, which needs `no_spawn_compiler_process`, and
+    %% that option is recorded in the `compile_info` chunk. So the two binaries
+    %% differ by one atom of metadata and by nothing else, and asserting raw
+    %% equality would only be asserting that this runtime never passes the
+    %% compiler an option.
+    %%
+    %% `beam_lib:md5/1` is the code, which is what this case is about: a step
+    %% added to one path and not the other changes it, and the option does not.
+    ?assertEqual(beam_lib:md5(Bin2), beam_lib:md5(Bin1)),
+
+    %% And the metadata difference is exactly the one option, so a second one
+    %% appearing later is a failure rather than a shrug.
+    ?assertEqual([no_spawn_compiler_process],
+                 compile_options(Bin2) -- compile_options(Bin1)),
+    ?assertEqual([], compile_options(Bin1) -- compile_options(Bin2)),
 
     %% And the rendered text is Core Erlang naming the entry point every caller
     %% goes through, not an opaque term printed with `~p`.
@@ -699,6 +715,11 @@ the_core_you_can_read_is_the_core_that_is_compiled(_) ->
     ?assert(string:find(Text, "'invoke'/6") =/= nomatch),
     ?assert(string:find(Text, "module") =/= nomatch),
     ok = wasm:destroy(I).
+
+compile_options(Bin) ->
+    {ok, {_Mod, [{compile_info, Info}]}} =
+        beam_lib:chunks(Bin, [compile_info]),
+    proplists:get_value(options, Info, []).
 
 %% A whole-module dump means counting positions to find the function you want.
 %% Real modules have hundreds, so the index the module itself uses is what a

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -51,7 +51,10 @@ groups() ->
        a_compile_outlives_the_process_that_asked_for_it,
        the_ring_keeps_only_the_newest,
        the_ring_normalises_what_it_is_given,
-       normalising_never_builds_the_representation]},
+       normalising_never_builds_the_representation,
+       a_compile_over_the_ceiling_is_refused_and_the_guest_still_answers,
+       the_ceiling_reaches_the_process_that_runs_the_compiler,
+       a_bad_ceiling_is_reported_once_and_compiles_anyway]},
      %% Its own group because it stops the application, which takes the store
      %% and its tables with it. A test process cannot delete them: they are
      %% bequeathed to `wasm_store_sup`.
@@ -85,6 +88,226 @@ end_per_testcase(_, _) ->
     ok.
 
 %%% ---------------------------------------------------------------- cases ---
+
+%% The ceiling fires, the outcome is a value naming the configured number, and
+%% the guest is unaffected. Watched to fail on the parent commit, where
+%% `compile_max_heap_words` is read by nothing: `refused` stays at zero and the
+%% diagnostic is absent.
+a_compile_over_the_ceiling_is_refused_and_the_guest_still_answers(_) ->
+    W = min_heap_words() * 2,
+    with_ceiling(W, fun () ->
+        M = build(many_wat(64)),
+        {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+        %% Before and after, because a killed compiler must leave the guest
+        %% exactly where it found it.
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        #{refused := R, crashed := Cr, compiled := C} = wasm_jit:counts(),
+        ?assertEqual({1, 0, 0}, {R, Cr, C}),
+        ?assertMatch([{refused, _, {limit, {compile_memory, W}}}],
+                     wasm_jit:diagnostics()),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ok = wasm:destroy(I)
+    end).
+
+%% The defect that killed the earlier design, pinned: a ceiling set on a process
+%% that only waits. This asserts the flag is on the process that is *inside* the
+%% OTP compiler, not on the one blocked in a receive.
+%%
+%% On the parent commit no spawned process carries a non-default ceiling, so
+%% `Found` is empty. On the design that was dropped, the pid carrying the
+%% ceiling would be the coordinator and its stacktrace would be a receive, which
+%% is why the stacktrace is asserted and not only the flag.
+the_ceiling_reaches_the_process_that_runs_the_compiler(_) ->
+    W = min_heap_words() * 100000,
+    with_ceiling(W, fun () -> reaches(W, 3) end).
+
+reaches(_W, 0) ->
+    ct:fail(never_caught_the_compiler);
+reaches(W, Tries) ->
+    %% Deliberately slow, so the child is alive long enough to be caught. A
+    %% spawn trace message is not a scheduling barrier: the child is runnable
+    %% the moment it exists and this process learns of it asynchronously, so
+    %% losing the race is ordinary and is retried rather than tolerated.
+    M = build(many_wat(400)),
+    Me = self(),
+    Runner = spawn(fun () ->
+                       {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+                       A = wasm:call(I, ~"f", [10]),
+                       %% Read here, while this process is certainly alive:
+                       %% asking after it has answered gets `undefined`.
+                       Me ! {answered, self(), A,
+                             process_info(self(), max_heap_size)}
+                   end),
+    1 = erlang:trace(Runner, true, [procs, set_on_spawn]),
+    Found = catch_compiler(Runner, []),
+    RunnerFlag =
+        receive {answered, Runner, A, RFlag} ->
+                ?assertEqual({ok, [11]}, A),
+                RFlag
+        after 120000 -> ct:fail(runner_never_answered)
+        end,
+    %% `trace/3` raises on a process that has already exited, and by here the
+    %% runner always has.
+    try erlang:trace(Runner, false, [procs, set_on_spawn]) catch _:_ -> 0 end,
+    flush_trace(),
+    case Found of
+        [] -> reaches(W, Tries - 1);
+        [{Flag, Stack} | _] ->
+            ?assertMatch(#{size := W, kill := true,
+                           include_shared_binaries := true}, Flag),
+            %% Caught inside the OTP compiler, which is the whole claim: the
+            %% ceiling is on the process doing the work and not on one waiting
+            %% for it.
+            ?assert(lists:any(fun ({compile, _, _, _}) -> true;
+                                  (_) -> false
+                              end, Stack)),
+            %% And the coordinator is not itself capped, which is what the
+            %% design that was dropped would have done: it set the ceiling on
+            %% the process blocked in a receive.
+            ?assertMatch({max_heap_size, #{size := 0}}, RunnerFlag)
+    end.
+
+%% Poll the child rather than suspending it the instant it appears. A spawn
+%% trace message is not a scheduling barrier and `initial_call` for a fun is
+%% `{erlang,apply,2}`, so neither the moment of arrival nor the name it started
+%% with says what this process is. What does say it is finding it *inside* the
+%% OTP compiler, and the compile takes seconds, so there is a wide window to
+%% look in. `process_info/2` on a running process is safe.
+catch_compiler(Runner, Acc) ->
+    receive
+        {trace, _, spawn, Child, _MFA} ->
+            case poll_child(Child, erlang:monotonic_time(millisecond) + 5000) of
+                skip -> catch_compiler(Runner, Acc);
+                Got -> catch_compiler(Runner, [Got | Acc])
+            end;
+        {trace, _, _, _, _} -> catch_compiler(Runner, Acc);
+        {trace, _, _, _} -> catch_compiler(Runner, Acc)
+    after 2000 -> Acc
+    end.
+
+poll_child(Child, Deadline) ->
+    case {process_info(Child, max_heap_size),
+          process_info(Child, current_stacktrace)} of
+        %% The reaper is spawned plain and carries no ceiling, so it is skipped
+        %% here without ever being mistaken for the compiler.
+        {{max_heap_size, #{size := S} = Flag}, {_, Stack}} when S > 0 ->
+            case lists:any(fun ({compile, _, _, _}) -> true;
+                               (_) -> false
+                           end, Stack) of
+                true -> {Flag, Stack};
+                false -> again(Child, Deadline)
+            end;
+        %% Dead, or not ours.
+        {undefined, _} -> skip;
+        _ -> skip
+    end.
+
+again(Child, Deadline) ->
+    case erlang:monotonic_time(millisecond) < Deadline of
+        true -> timer:sleep(5), poll_child(Child, Deadline);
+        false -> skip
+    end.
+
+flush_trace() ->
+    receive
+        {trace, _, _, _, _} -> flush_trace();
+        {trace, _, _, _} -> flush_trace()
+    after 0 -> ok
+    end.
+
+%% A mistyped value must not turn the tier off, must not spend a diagnostics
+%% row, and must be said once per uninterrupted occurrence. The last row is the
+%% upper bound, which nothing documents: `size` has to be a small integer.
+a_bad_ceiling_is_reported_once_and_compiles_anyway(_) ->
+    Min = min_heap_words(),
+    %% Every shape of wrong, including the two edges. `Min - 1` is where
+    %% `spawn_opt` raises `badarg` at the bottom and `1 bsl 59` is where it
+    %% raises at the top, which nothing documents.
+    [bad_ceiling(V) || V <- [banana, -1, 1.5, Min - 1, 1 bsl 59]],
+    %% Said once per uninterrupted occurrence of the same value, which is the
+    %% part a `persistent_term` memo could not promise: two compilers reading
+    %% it concurrently would both see the old value and both warn.
+    ?assertEqual(1, warnings(fun () -> two_compiles(banana) end)),
+    ?assertEqual(1, warnings(fun () -> two_compiles(banana),
+                                       two_compiles(banana) end)),
+    %% Corrected, then mistyped the same way again: the condition cleared, so
+    %% it is news a second time. This is what fails if the server is told only
+    %% about the failures.
+    ?assertEqual(2, warnings(fun () -> two_compiles(banana),
+                                       two_compiles(Min * 4),
+                                       two_compiles(banana) end)),
+    %% Two different wrong values are two conditions, which is what fails if
+    %% the memo keys on the environment key instead of the raw term.
+    ?assertEqual(2, warnings(fun () -> two_compiles(banana),
+                                       two_compiles(-1) end)),
+    %% And the two values that mean "no ceiling" say nothing at all.
+    [begin
+         wasm_jit:reset_counts(),
+         with_ceiling(V, fun () ->
+             ?assertEqual(0, wasm_jit:max_heap_words()),
+             ?assertEqual(0, map_get(max_heap_words, wasm_jit:compile_limits()))
+         end)
+     end || V <- [0, undefined]],
+    ok.
+
+%% Count the warnings a body produces, by being the `logger` handler for it.
+warnings(Body) ->
+    reset_config_memo(),
+    ok = logger:add_handler(?MODULE, ?MODULE, #{config => #{pid => self()}}),
+    try
+        Body(),
+        drain_warnings(0)
+    after
+        _ = logger:remove_handler(?MODULE),
+        reset_config_memo()
+    end.
+
+drain_warnings(N) ->
+    receive {warned, _} -> drain_warnings(N + 1)
+    after 200 -> N
+    end.
+
+%% The `logger` handler callback. Only this module's own message is counted, so
+%% anything else the node says during the body is ignored.
+log(#{level := warning, msg := {Fmt, Args}}, #{config := #{pid := Pid}}) ->
+    Text = unicode:characters_to_list(io_lib:format(Fmt, Args)),
+    case string:find(Text, "compile_max_heap_words") of
+        nomatch -> ok;
+        _ -> Pid ! {warned, Text}, ok
+    end;
+log(_, _) ->
+    ok.
+
+two_compiles(Value) ->
+    with_ceiling(Value, fun () ->
+        M = build(many_wat(8)),
+        [begin
+             {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+             _ = wasm:call(I, ~"f", [10]),
+             ok = wasm:destroy(I)
+         end || _ <- [1, 2]]
+    end).
+
+bad_ceiling(Value) ->
+    wasm_jit:reset_counts(),
+    reset_config_memo(),
+    with_ceiling(Value, fun () ->
+        ?assertEqual(0, wasm_jit:max_heap_words()),
+        M = build(many_wat(8)),
+        {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        {ok, J} = wasm:instantiate(M, #{}, sync(whole())),
+        ?assertEqual({ok, [11]}, wasm:call(J, ~"f", [10])),
+        %% The tier still works, and nothing was counted as a failure of it.
+        #{compiled := C, refused := R, failed := F, crashed := Cr} =
+            wasm_jit:counts(),
+        ?assert(C > 0),
+        ?assertEqual({0, 0, 0}, {R, F, Cr}),
+        %% The complaint is not a diagnostic and must not evict one.
+        ?assertEqual([], wasm_jit:diagnostics()),
+        ok = wasm:destroy(I),
+        ok = wasm:destroy(J)
+    end).
 
 %% Reproduces the defect. On the parent commit `{limit, too_many_functions}`
 %% escapes as an exception, the compiler swallows it, and every counter stays
@@ -597,6 +820,38 @@ loading_owners() ->
             Pid <- maps:values(Leases), is_pid(Pid)].
 
 opts() -> #{compile => true, compile_after => 1}.
+
+min_heap_words() ->
+    {min_heap_size, Min} = erlang:system_info(min_heap_size),
+    Min.
+
+%% Set, run, restore. `undefined` means the key was absent, which is not the
+%% same as it being present and set to `undefined`.
+%%
+%% It does *not* reset the server's held value on the way in: several of the
+%% cases above depend on what it is holding from the previous body.
+with_ceiling(Value, F) ->
+    Was = application:get_env(wasm, compile_max_heap_words),
+    ok = application:set_env(wasm, compile_max_heap_words, Value),
+    try F()
+    after
+        case Was of
+            undefined -> application:unset_env(wasm, compile_max_heap_words);
+            {ok, Old} -> application:set_env(wasm, compile_max_heap_words, Old)
+        end,
+        ok
+    end.
+
+%% Guarded, so this helper works on a commit that has no `observe_config/1`.
+%% Without the guard every case using it fails with `undef` on the parent, which
+%% is a failure that proves nothing: it would look identical if the behaviour
+%% under test were present and correct.
+reset_config_memo() ->
+    _ = code:ensure_loaded(wasm_code_slots),
+    case erlang:function_exported(wasm_code_slots, observe_config, 1) of
+        true -> wasm_code_slots:observe_config(ok);
+        false -> ok
+    end.
 
 build(Wat) ->
     {ok, P} = wasm_wat:module(Wat),

--- a/test/wasm_jit_lifetime_SUITE.erl
+++ b/test/wasm_jit_lifetime_SUITE.erl
@@ -23,7 +23,8 @@
 -include_lib("wasm/include/wasm_exec.hrl").
 
 all() ->
-    [a_compiler_killed_mid_flight_leaves_no_slot_behind,
+    [killing_the_compiler_takes_the_otp_compiler_with_it,
+     a_compiler_killed_mid_flight_leaves_no_slot_behind,
      destroying_the_instance_while_it_compiles_is_harmless,
      a_caller_killed_inside_generated_code_leaves_the_slot_usable,
      every_slot_pinned_by_a_leaked_lease_still_recovers,
@@ -58,6 +59,83 @@ init_per_testcase(_, Config) -> wasm_test_slots:reset(), Config.
 end_per_testcase(_, _) -> wasm_test_slots:reset(), ok.
 
 %%% --------------------------------------------------------------- cases ---
+
+%% The hole nothing in this repo has ever tested, and it is not ours: OTP's
+%% `compile:forms/2` spawns its worker with `spawn_monitor/1`, which monitors
+%% and does *not* link. So a compiler killed by `wasm_jit_sup`'s `brutal_kill`,
+%% or by `application:stop(wasm)`, leaves the OTP compiler running to completion
+%% holding its own copy of the forms, with nothing in the tree able to see or
+%% stop it.
+%%
+%% On the parent commit step 2 finds OTP's child and step 4 times out, because
+%% that child compiles to completion whatever happens to the process that asked
+%% for it. The anti-vacuity guard is step 2: if no compiler is ever caught, the
+%% case has proved nothing and says so instead of passing.
+-define(ORPHAN_MS, 8000).
+-define(COMPILE_MS, 40000).
+
+killing_the_compiler_takes_the_otp_compiler_with_it(_) ->
+    wasm_jit:reset_counts(),
+    %% Big enough that the compile is seconds rather than milliseconds, so
+    %% there is a window in which to catch and kill it.
+    M = big_module(2000),
+    {ok, I} = wasm:instantiate(M, #{}, #{compile => true, compile_after => 1,
+                                         compile_whole => true}),
+    ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+    Started = erlang:monotonic_time(millisecond),
+    %% Caught once, by identity, and then asked only whether it is alive.
+    %%
+    %% Asking "is any process currently inside the compiler" twice does not
+    %% work, and the way it fails is a false pass: the test is a sample of a
+    %% stacktrace against a handful of module names, and a compiler moves
+    %% between passes constantly. The first draft found the orphan, killed
+    %% nothing that mattered, sampled again one millisecond later while that
+    %% same live process happened to be inside a pass the list does not name,
+    %% and concluded it had gone. `is_process_alive/1` has no such gap.
+    Pid = catch_orphan(erlang:monotonic_time(millisecond) + 30000),
+    Waited = erlang:monotonic_time(millisecond) - Started,
+    ok = kill_compilers(),
+    ?assertEqual(ok, until(fun () -> not is_process_alive(Pid) end, ?ORPHAN_MS),
+                 "a killed compiler left the OTP compiler running"),
+    %% Both guards against a vacuous pass, and the second one is the one that
+    %% caught this case cheating. The compiler is killed a second or two in and
+    %% this module needs about forty, so an orphan is still working long after
+    %% the window closes. Sized at 600 functions it needed eleven seconds
+    %% against a ten second window, and the case passed on the parent commit by
+    %% letting the orphan finish rather than by anything killing it.
+    ?assert(Waited < 25000),
+    Total = erlang:monotonic_time(millisecond) - Started,
+    ?assert(Total < ?COMPILE_MS div 2),
+    ok = wasm:destroy(I).
+
+%% The first process found inside the OTP compiler that is not one of ours.
+%% Fails rather than returns when there is none, because a case that never
+%% caught a compiler has proved nothing.
+catch_orphan(Deadline) ->
+    case otp_compilers() of
+        [Pid | _] -> Pid;
+        [] ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true -> timer:sleep(20), catch_orphan(Deadline);
+                false -> ct:fail("no OTP compiler ever ran, so this case "
+                                 "proved nothing")
+            end
+    end.
+
+%% `f` plus N-1 more, each with a body long enough that compiling all of them
+%% takes seconds.
+big_module(N) ->
+    Wat = iolist_to_binary(
+            ["(module (func (export \"f\") (param i32) (result i32)
+                local.get 0 i32.const 1 i32.add)",
+             [["(func (param i32) (result i32) local.get 0",
+               [" i32.const 1 i32.add" || _ <- lists:seq(1, 40)], ")"]
+              || _ <- lists:seq(2, N)],
+             ")"]),
+    {ok, P} = wasm_wat:module(Wat),
+    {ok, Mod} = wasm_validate:module(P),
+    Mod.
+
 
 a_compiler_killed_mid_flight_leaves_no_slot_behind(_) ->
     %% The reservation is owned by the process doing the work precisely so that
@@ -1008,6 +1086,38 @@ hashed(N) ->
                                    <<0>>, Body])]),
     {ok, M} = wasm:compile(Bin, #{identity => {sha256, crypto:hash(sha256, Bin)}}),
     M.
+
+%% Every process inside the OTP compiler that is not one of ours.
+%%
+%% The exclusion is the whole point and the first version did not have it. A
+%% process *waiting* in `compile:do_compile/2`'s receive has `compile` frames in
+%% its stacktrace just as the process doing the work does, so without excluding
+%% the slot owners this finds our own coordinator, and killing the coordinator
+%% then satisfies the assertion. The case passed on the parent commit, which is
+%% precisely the vacuous pass it was written to avoid.
+%%
+%% Written in terms both this commit and its parent have, so it can be watched
+%% to fail: it names no function this branch introduced.
+otp_compilers() ->
+    Ours = [self() | loading_owner_pids()],
+    [P || P <- processes(), not lists:member(P, Ours), in_compiler(P)].
+
+loading_owner_pids() ->
+    [Pid || {_N, _G, {loading, _}, Leases} <- ets:tab2list(wasm_code_slots),
+            Pid <- maps:values(Leases), is_pid(Pid)].
+
+in_compiler(P) ->
+    case process_info(P, current_stacktrace) of
+        {current_stacktrace, Stack} ->
+            lists:any(fun ({compile, _, _, _}) -> true;
+                          ({beam_ssa_opt, _, _, _}) -> true;
+                          ({beam_ssa_pre_codegen, _, _, _}) -> true;
+                          ({v3_core, _, _, _}) -> true;
+                          ({sys_core_fold, _, _, _}) -> true;
+                          (_) -> false
+                      end, Stack);
+        undefined -> false
+    end.
 
 free_slots() ->
     length([N || {N, _G, free, _} <- ets:tab2list(wasm_code_slots)]).


### PR DESCRIPTION
`compile:forms/2` does its work in a process it spawns itself and gives a caller
no way to configure it, so a `max_heap_size` set on the process `wasm_jit`
spawns bound a process that only waits. `PERF.md` recorded that as 0.34 GB
watched against a 6.19 GB node, and recorded `no_spawn_compiler_process` on the
coordinator as costing 293 s against 167. Neither shipped.

Neither experiment tried the third shape: the same option in a *fresh,
disposable* process, which is the lifecycle OTP's own child already has.

## What the measurement says

`bench/paths/compileheap.erl`, three arms compiling the same `Core`, five
samples interleaved in both orderings, load 2.0 to 5.2, walls from untraced
runs:

| arm | min s | med s | max s | runner MB | worker MB |
| --- | ---: | ---: | ---: | ---: | ---: |
| `otp`, as called today | 70.4 | 72.0 | 76.6 | 169.2 | **2054.8** |
| `inline`, on the coordinator | 71.8 | 72.7 | 77.2 | 2102.7 | 2102.7 |
| `child`, a fresh process | 71.0 | 71.6 | 74.6 | **141.0** | 2467.8 |

`R = child/otp = 1.009`, against a gate of 1.10 written before the numbers
arrived. `beam_lib:md5` is identical across all thirty compiles.

The 0.34 GB finding reproduces exactly: a ceiling on the process `wasm_jit`
spawns would watch 141 MB while the compiler spends 2,055 MB.

**The 293 s row does not reproduce.** `inline` is 2% over `otp`, not 75%, and
that is with the runner holding the instance and the whole unit IR live across
the compile, which is the condition the larger live set was supposed to explain.
The conclusion the plan predicted holds; its mechanism does not. Recorded as an
open question rather than a win.

## What changes

`wasm_core:run_compiler/4` spawns the process that runs `compile:forms/2`,
monitored (never linked: a `max_heap_size` kill exits `killed`, which an
untrapping owner would die of before recording anything), with a reaper that
stops it if its owner dies.

Unconditional rather than gated on the ceiling, because the second thing it buys
is for everyone: `spawn_monitor/1` does not link, so until now a compiler killed
by its supervisor or by `application:stop(wasm)` left the OTP compiler running
to completion, holding its copy of the forms, with nothing able to see it.

`compile_max_heap_words` is **off by default**. There is still no number right
for every guest: QuickJS's compiler peaks near 2.5 GB, CPython's whole-module
compile reached 33 GB, and CPython's legitimate compile sits between them.
A compile over the ceiling is *refused*, so the guest interprets and answers as
before.

## Notes

Four ways this was measured wrong first, all recorded in `PERF.md`:
`erlang:monotonic_time/1` is negative at VM start, so a sampler seeded at 0
never fires; `[procs, set_on_spawn]` delivers zero GC events; `monotonic_timestamp`
renames every message to `trace_ts`; and `erts_debug:flat_size(Unit)` is not the
IR size.

The orphan case passed on the parent three times before it was made to fail
there, and the fourth attempt caught a bug in the fix itself: the reaper was
spawned as `spawn(fun () -> reap(Owner, self()) end)`, where `self()` is the
reaper's own pid, so it watched itself and left the compiler running.

45 suites, lint, xref and dialyzer clean. Every new case run against the parent
commit and watched to fail.