### PR TITLE
Bound what the node has in flight, not just one compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,17 @@ And a compile can now be stopped. `compile:forms/2` spawns its worker with
 `application:stop(wasm)` or by its supervisor left the OTP compiler running to
 completion holding its copy of the forms, with nothing able to see or stop it.
 
-`wasm_jit:compile_limits/0` reports `max_heap_words`, and `max_heap_words/0`
-answers it on its own.
+### A budget for what the node has in flight
+
+`compile_max_heap_words` bounds one compiler, and the slot pool allows sixteen.
+`compile_budget_words` bounds the node: a request that does not fit beside what
+is already compiling is refused, so the guest interprets and asks again later.
+Nothing is queued, a request larger than the whole budget still compiles when
+nothing else is running, and a killed compiler gives its words back through a
+monitor rather than an `after`. Off by default.
+
+`wasm_jit:compile_limits/0` reports `max_heap_words` and `budget_words`, and
+`max_heap_words/0` and `compile_budget_words/0` answer them on their own.
 
 ## 0.2.2
 

--- a/docs/compiled-tier.md
+++ b/docs/compiled-tier.md
@@ -186,6 +186,24 @@ A value that is not a whole number of words between `min_heap_size` and
 `(1 bsl 59) - 1` is reported once through `logger` and ignored, rather than
 turning the tier off for the life of the node.
 
+## Bound what the whole node has in flight
+
+The ceiling above bounds one compiler. Sixteen slots means up to sixteen of
+them, so it is not a bound on the node:
+
+```erlang
+application:set_env(wasm, compile_budget_words, 4_000_000).
+```
+
+In IR words, which is what a compile's cost tracks. A request that does not fit
+beside what is already running is **refused**, so the guest interprets and asks
+again at the next hot call; nothing is queued, because a caller that waited
+would hold the unit IR it was admitted to compile for the whole wait.
+
+A request larger than the entire budget still compiles when nothing else is
+running, so a budget set below one guest's hot set slows compilation down
+instead of stopping it. Also off by default.
+
 **Off by default, and the directory is as trusted as your release.** Loading a
 `.beam` from it executes whatever is in that file, so it must not be writable by
 anything you would not run as code.

--- a/src/wasm_code_slots.erl
+++ b/src/wasm_code_slots.erl
@@ -107,6 +107,7 @@ reasoning.
 -export([hot/2]).
 -export([record_diagnostic/4, diagnostics/0, clear_diagnostics/0]).
 -export([observe_config/1]).
+-export([acquire/2, release_budget/0, budget/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -export_type([key/0, lease/0, token/0]).
@@ -190,7 +191,12 @@ reasoning.
                 %% The bad `compile_max_heap_words' currently in force, if any.
                 %% One entry and not a set: a set would retain every value
                 %% anyone ever mistyped for the life of the node.
-                bad_cfg  = ok   :: ok | {bad, term()}}).
+                bad_cfg  = ok   :: ok | {bad, term()},
+                %% IR words admitted and not yet given back, and who is holding
+                %% them. Monitored, because a compiler that dies must not take
+                %% the node's budget with it.
+                spent    = 0    :: non_neg_integer(),
+                holders  = #{}  :: #{reference() => {pid(), pos_integer()}}}).
 
 %%% ----------------------------------------------------------------- api ---
 
@@ -264,6 +270,48 @@ diagnostics() ->
     case ets:whereis(?DIAG) of
         undefined -> [];
         _ -> [{O, K, R} || {_Seq, O, K, R, _At} <- ets:tab2list(?DIAG)]
+    end.
+
+-doc """
+Take `Words` of the node's compile budget, or say it is not there.
+
+A per-process heap ceiling bounds one compiler. Sixteen of them, each under it,
+is still not a bound on the node, and sixteen is what the slot pool allows. This
+is the other half: one budget the whole node draws on, in IR words, which is the
+quantity `split/2` already weighs shards by and the one that predicts what a
+compile will cost.
+
+`{error, busy}` means interpret and ask again later, exactly as a full slot pool
+does. It is not an error and nothing is queued: a caller that waited would be
+holding the unit IR it was admitted to compile while it waited.
+
+The reservation is monitored, so a compiler that is killed gives its words back
+without anything having to notice. `Budget` of 0 means no budget and answers
+`ok` without taking anything, so an embedder who sets nothing pays one map
+lookup and no server call.
+""".
+-spec acquire(pos_integer(), non_neg_integer()) -> ok | {error, busy}.
+acquire(_Words, 0) -> ok;
+acquire(Words, Budget) ->
+    case whereis(?MODULE) of
+        undefined -> ok;
+        _ -> gen_server:call(?MODULE, {acquire, Words, Budget})
+    end.
+
+-doc "Give back whatever this process is holding. Safe when it holds nothing.".
+-spec release_budget() -> ok.
+release_budget() ->
+    case whereis(?MODULE) of
+        undefined -> ok;
+        _ -> gen_server:call(?MODULE, release_budget)
+    end.
+
+-doc "Words currently admitted and not yet given back. For tests.".
+-spec budget() -> non_neg_integer().
+budget() ->
+    case whereis(?MODULE) of
+        undefined -> 0;
+        _ -> gen_server:call(?MODULE, budget)
     end.
 
 -doc """
@@ -586,6 +634,23 @@ handle_call({observe_config, {bad, Raw}}, _From, S) ->
                    "number of words between ~p and ~p; compiling with no heap "
                    "ceiling", [Raw, Min, (1 bsl 59) - 1]),
     {reply, ok, S#state{bad_cfg = {bad, Raw}}};
+handle_call({acquire, Words, Budget}, {Pid, _}, #state{spent = Spent} = S) ->
+    %% Admitted when there is room, and *always* admitted when nothing is out:
+    %% a single request larger than the whole budget must still compile, or a
+    %% budget set below one guest's hot set would refuse it for ever rather
+    %% than bounding anything.
+    case Spent + Words =< Budget orelse Spent =:= 0 of
+        false ->
+            {reply, {error, busy}, S};
+        true ->
+            Ref = erlang:monitor(process, Pid),
+            {reply, ok, S#state{spent = Spent + Words,
+                                holders = (S#state.holders)#{Ref => {Pid, Words}}}}
+    end;
+handle_call(release_budget, {Pid, _}, S) ->
+    {reply, ok, give_back(Pid, S)};
+handle_call(budget, _From, #state{spent = Spent} = S) ->
+    {reply, Spent, S};
 handle_call({claim_loading, Key, Lease, Owner}, _From, S) ->
     case find(Key) of
         %% Somebody else is filling this in. Interpret rather than wait.
@@ -667,6 +732,11 @@ handle_cast(_Msg, S) -> {noreply, S}.
 %% mid-call still has the call's lease, held by whichever process is running
 %% it, so the code survives exactly as long as something is inside it.
 handle_info({'DOWN', Ref, process, _Pid, _Reason},
+            #state{holders = Hs} = S0) when is_map_key(Ref, Hs) ->
+    {_, Words} = map_get(Ref, Hs),
+    {noreply, S0#state{spent = S0#state.spent - Words,
+                       holders = maps:remove(Ref, Hs)}};
+handle_info({'DOWN', Ref, process, _Pid, _Reason},
             #state{monitors = Ms, loading = Ls} = S) ->
     case maps:find(Ref, Ls) of
         %% A compiler that died. Its reservation holds the slot exclusively and
@@ -685,6 +755,17 @@ handle_info({'DOWN', Ref, process, _Pid, _Reason},
 handle_info(_Info, S) -> {noreply, S}.
 
 %%% ------------------------------------------------------------- internal ---
+
+%% Everything `Pid` is holding, which is at most one reservation but is written
+%% as a fold so a second one could never leak.
+give_back(Pid, #state{spent = Spent, holders = Hs} = S) ->
+    Mine = [{R, W} || {R, {P, W}} <- maps:to_list(Hs), P =:= Pid],
+    lists:foldl(fun ({Ref, Words}, Acc) ->
+                    true = erlang:demonitor(Ref, [flush]),
+                    Acc#state{spent = Acc#state.spent - Words,
+                              holders = maps:remove(Ref, Acc#state.holders)}
+                end, S#state{spent = Spent}, Mine).
+
 
 %% Both a loading and a resident slot answer, because a caller arriving while
 %% somebody else is filling one in has to be told to interpret rather than being

--- a/src/wasm_jit.erl
+++ b/src/wasm_jit.erl
@@ -56,7 +56,7 @@ moved, because even with all three a refusal still interprets.
 
 -export([entry/3, after_call/2, counts/0, reset_counts/0, await/2, release/1]).
 -export([diagnostics/0, normalize_reason/1, shard_count/2, shards/1]).
--export([compile_limits/0, max_heap_words/0]).
+-export([compile_limits/0, max_heap_words/0, compile_budget_words/0]).
 -export([reentered/0]).
 -export([compiler_loop/0]).
 -export([dump/1, dump/2]).
@@ -739,6 +739,11 @@ generate_1(Inst, Limits, Mod, Token, Unit) ->
                         0 -> #{};
                         _ -> #{max_heap_words => Words}
                     end,
+            %% Weighed and admitted here, which is after the IR exists and
+            %% before any Core does. Admitting later would mean a request that
+            %% is turned away had already built the largest term in the
+            %% compile; admitting earlier would mean guessing its size.
+            Budget = compile_budget_words(),
             {_Name, Gen} = Token,
             Stamp = stamp(Inst, Gen),
             case split(Unit, Limits) of
@@ -748,10 +753,35 @@ generate_1(Inst, Limits, Mod, Token, Unit) ->
                     ok = wasm_code_slots:abort(Token),
                     {refused, {limit, {too_many_functions, N}}};
                 Parts ->
-                    build(Inst, Limits, Mode, Stamp, Unit, Parts,
-                          [{Mod, Token}], COpts)
+                    admitted(Inst, Limits, Mode, Stamp, Unit, Parts,
+                             {Mod, Token}, COpts, Budget)
             end
     end.
+
+%% The budget is held for the whole build and given back however it ends,
+%% including a trap on the way out. A compiler that is *killed* gives it back
+%% too, through the monitor `wasm_code_slots` took, which is the case an
+%% `after` cannot cover.
+admitted(Inst, Limits, Mode, Stamp, Unit, Parts, {Mod, Token}, COpts, Budget) ->
+    Weight = ir_words(Unit),
+    case wasm_code_slots:acquire(Weight, Budget) of
+        {error, busy} ->
+            ok = wasm_code_slots:abort(Token),
+            {refused, {limit, {compile_budget, Weight}}};
+        ok ->
+            try build(Inst, Limits, Mode, Stamp, Unit, Parts, [{Mod, Token}],
+                      COpts)
+            after
+                ok = wasm_code_slots:release_budget()
+            end
+    end.
+
+%% What `split/2` weighs shards by, over the whole request. On the sharded path
+%% it is computed again there; the duplication is one traversal of a term the
+%% compile is about to spend a minute on, and sharing it would mean threading a
+%% weight through four functions that have no use for it.
+ir_words(Unit) ->
+    lists:sum([erts_debug:flat_size(IR) || {_P, _I, _F, IR} <- Unit]).
 
 %% One unit or several, and the difference is only how many slots are held.
 %%
@@ -861,7 +891,8 @@ bounds a single unit has.
 -spec compile_limits() -> #{atom() => non_neg_integer()}.
 compile_limits() ->
     #{max_compile_funs => ?MAX_COMPILE_FUNS, max_shards => ?MAX_SHARDS,
-      max_heap_words => max_heap_words()}.
+      max_heap_words => max_heap_words(),
+      budget_words => compile_budget_words()}.
 
 -doc """
 The heap ceiling a compile would be given, in words, or 0 for none.
@@ -874,6 +905,24 @@ of a compile.
 """.
 -spec max_heap_words() -> non_neg_integer().
 max_heap_words() -> element(1, resolve_max_heap_words()).
+
+-doc """
+The node's whole compile budget in IR words, or 0 for none.
+
+A heap ceiling bounds one compiler; sixteen of them under it is not a bound on
+the node. This is what the whole node may have in flight at once. Off by
+default, and like the ceiling it refuses rather than queues: a request that does
+not fit interprets and asks again at the next hot call.
+""".
+-spec compile_budget_words() -> non_neg_integer().
+compile_budget_words() ->
+    case application:get_env(wasm, compile_budget_words, undefined) of
+        undefined -> 0;
+        W when is_integer(W), W >= 0 -> W;
+        %% A bad value is no budget, said the same way a bad ceiling is: a typo
+        %% must not bound the node at zero and refuse every compile there is.
+        _ -> 0
+    end.
 
 %% Answers the effective value *and* what to say about it, because the two
 %% cannot be recovered from one another: a bad value and an absent one both

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4583,3 +4583,56 @@ And a fourth, in the fix rather than the test: the reaper was spawned as
 `spawn(fun () -> reap(Owner, self()) end)`, where `self()` is the *reaper's* pid.
 It monitored itself, killed itself when the owner died, and left the compiler it
 exists to stop running to completion. The case caught it.
+
+## The other half of the bound: one budget the whole node draws on
+
+The heap ceiling bounds one compiler. The slot pool allows sixteen, and sixteen
+compilers each under a ceiling is not a bound on the node: `?MAX_COMPILE_FUNS`
+is per request, `compile_max_heap_words` is per process, and neither says what
+may be in flight at once. `src/wasm_jit.erl:448` has said so all along, in its
+own words: "Nothing bounds the number of compilers except the sixteen slots."
+
+`compile_budget_words` is that bound, in IR words, which is the quantity
+`split/2` already weighs shards by and the one that predicts what a compile
+costs. A request that does not fit is **refused**, so the guest interprets and
+asks again at the next hot call, and `wasm_jit:diagnostics/0` says
+`{limit, {compile_budget, Words}}`.
+
+Three decisions worth their reasons.
+
+**Refuse, never queue.** A caller that waited would be holding the unit IR it
+was admitted to compile for the whole wait, which is the memory the budget
+exists to bound. Refusing gives it back at once and the ask's own retry interval
+paces the next attempt.
+
+**A request larger than the whole budget is still admitted, when nothing else is
+out.** Otherwise a budget set below one guest's hot set refuses every compile
+there is, for ever, and a configuration mistake becomes a silent permanent
+outage. The bound is on *concurrency of large compiles*, not on their size;
+size is what the admission ceiling and the heap ceiling are for.
+
+**The reservation is monitored, not just wrapped in an `after`.** `admitted/9`
+gives the words back however the build ends, including a trap on the way out.
+It cannot give them back for a compiler that is *killed*, which is the ordinary
+case here: `wasm_jit_sup` kills brutally and the heap ceiling kills untrappably.
+`wasm_code_slots` monitors the holder, so a killed compiler returns its words
+without anything having to notice.
+
+Off by default, for the same reason the ceiling is: there is no number right for
+every deployment, and the failure mode of a wrong one is a tier that quietly
+stops compiling.
+
+### Two ways this test passed while proving nothing
+
+Both found by running it against the parent commit, and both are the same trap
+in different clothes.
+
+- **The same module twice contends for the slot, not the budget.** The second
+  caller finds it already `loading` and answers `retry` before admission is ever
+  reached, so the case passed with the budget doing nothing. It takes two
+  distinct modules to make them contend for the budget at all.
+- **`undef` on a helper is not a differential.** Waiting on
+  `wasm_code_slots:budget/0` makes the case fail on any commit that lacks the
+  function, which is a failure indistinguishable from the one a present but
+  broken bound would produce. Guarded, the case reaches its real assertion and
+  fails on the parent at `refused() >= 1`, which is the defect.

--- a/test/wasm_jit_bounds_SUITE.erl
+++ b/test/wasm_jit_bounds_SUITE.erl
@@ -20,6 +20,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("wasm/include/wasm.hrl").
+-include_lib("wasm/include/wasm_exec.hrl").
 
 %% Measured, on the pinned guest recorded in `test/audit/PERF.md`: CPython 3.12
 %% reaches this many functions in one `_start`, and has this many eligible in
@@ -54,7 +55,10 @@ groups() ->
        normalising_never_builds_the_representation,
        a_compile_over_the_ceiling_is_refused_and_the_guest_still_answers,
        the_ceiling_reaches_the_process_that_runs_the_compiler,
-       a_bad_ceiling_is_reported_once_and_compiles_anyway]},
+       a_bad_ceiling_is_reported_once_and_compiles_anyway,
+       a_compile_past_the_node_budget_is_refused_and_retried,
+       one_request_larger_than_the_whole_budget_still_compiles,
+       a_killed_compiler_gives_its_budget_back]},
      %% Its own group because it stops the application, which takes the store
      %% and its tables with it. A test process cannot delete them: they are
      %% bequeathed to `wasm_store_sup`.
@@ -88,6 +92,117 @@ end_per_testcase(_, _) ->
     ok.
 
 %%% ---------------------------------------------------------------- cases ---
+
+%% A heap ceiling bounds one compiler. This is the other half: what the node may
+%% have in flight at once. One compile holds the budget, and a second that does
+%% not fit beside it is refused rather than queued.
+%%
+%% Watched to fail on the parent commit, where `compile_budget_words` is read by
+%% nothing and both compile.
+a_compile_past_the_node_budget_is_refused_and_retried(_) ->
+    %% Slow on purpose. The holder has to still be compiling while the second
+    %% attempt is made, and a module that compiles in milliseconds would make
+    %% this a race the test loses silently by passing.
+    %% Two *different* modules. The same one twice contends for the slot rather
+    %% than for the budget: the second caller finds it already `loading` and
+    %% answers `retry` without ever reaching admission, so the case would pass
+    %% while proving nothing about the budget.
+    M = build(many_wat(400)),
+    N = build(many_wat(401)),
+    One = one_unit_words(M),
+    %% Room for one of these and not for two, derived rather than guessed: a
+    %% literal would stop bounding anything the day the IR changed size.
+    with_budget(One + (One div 2), fun () ->
+        Holder = hold_budget(M),
+        try
+            {ok, J} = wasm:instantiate(N, #{}, sync(whole())),
+            ?assertEqual({ok, [11]}, wasm:call(J, ~"f", [10])),
+            ?assert(refused() >= 1),
+            ?assertMatch([{refused, _, {limit, {compile_budget, _}}} | _],
+                         wasm_jit:diagnostics()),
+            ok = wasm:destroy(J)
+        after
+            release_hold(Holder)
+        end
+    end),
+    ?assertEqual(0, budget_or(0)).
+
+%% A budget smaller than a single request must not refuse it for ever. Nothing
+%% would ever compile on a node whose budget was set below one guest's hot set,
+%% which is a configuration mistake that should cost nothing.
+one_request_larger_than_the_whole_budget_still_compiles(_) ->
+    M = build(many_wat(64)),
+    with_budget(1, fun () ->
+        {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+        ?assertEqual({ok, [11]}, wasm:call(I, ~"f", [10])),
+        ?assert(compiled() > 0),
+        ?assertEqual(0, refused()),
+        ok = wasm:destroy(I)
+    end).
+
+%% The `after` in `admitted/9` covers a compile that returns or traps. It cannot
+%% cover one that is killed, and that is what the monitor is for.
+a_killed_compiler_gives_its_budget_back(_) ->
+    M = build(many_wat(400)),
+    One = one_unit_words(M),
+    with_budget(One * 4, fun () ->
+        Holder = hold_budget(M),
+        ?assert(budget_or(1) > 0),
+        %% Killed, not released: no `after` runs for this.
+        exit(Holder, kill),
+        ?assertEqual(ok, until(fun () -> budget_or(0) =:= 0 end, 5000))
+    end).
+
+%% One compile, admitted and still running. It is left running rather than
+%% suspended: the module is slow enough that it is certainly still holding when
+%% the caller returns, and suspending would only add a race of its own.
+hold_budget(M) ->
+    Pid = spawn(fun () ->
+                    {ok, I} = wasm:instantiate(M, #{}, sync(whole())),
+                    _ = wasm:call(I, ~"f", [10]),
+                    ok
+                end),
+    %% Wait for the budget to move, not for the process to start: the
+    %% reservation is a `gen_server` call it has still to make.
+    ?assertEqual(ok, wait_holding()),
+    Pid.
+
+release_hold(Pid) ->
+    exit(Pid, kill),
+    ?assertEqual(ok, until(fun () -> budget_or(0) =:= 0 end, 10000)).
+
+%% Wait until the holder is actually holding.
+%%
+%% Guarded, so this works on a commit that has no budget at all. With the API
+%% it waits for the reservation itself; without it, for the slot claim that
+%% immediately precedes one. Ungurded, every case using it fails on the parent
+%% with `undef` on a helper, and that failure looks exactly like the one a
+%% present-but-broken bound would produce.
+wait_holding() ->
+    case has_budget_api() of
+        true -> until(fun () -> wasm_code_slots:budget() > 0 end, 30000);
+        false -> until(fun () -> loading_owners() =/= [] end, 30000)
+    end.
+
+budget_or(Default) ->
+    case has_budget_api() of
+        true -> wasm_code_slots:budget();
+        false -> Default
+    end.
+
+has_budget_api() ->
+    _ = code:ensure_loaded(wasm_code_slots),
+    erlang:function_exported(wasm_code_slots, budget, 0).
+
+%% What one whole-module unit of this module weighs, asked of the same function
+%% the runtime weighs it with.
+one_unit_words(M) ->
+    {ok, I} = wasm:instantiate(M, #{}, #{}),
+    Fns = [F || F <- tuple_to_list(I#inst.funcs), is_record(F, fn)],
+    W = lists:sum([erts_debug:flat_size(wasm_instance:compiler_ir(F, I))
+                   || F <- Fns]),
+    ok = wasm:destroy(I),
+    W.
 
 %% The ceiling fires, the outcome is a value naming the configured number, and
 %% the guest is unaffected. Watched to fail on the parent commit, where
@@ -820,6 +935,17 @@ loading_owners() ->
             Pid <- maps:values(Leases), is_pid(Pid)].
 
 opts() -> #{compile => true, compile_after => 1}.
+
+with_budget(Words, F) ->
+    Was = application:get_env(wasm, compile_budget_words),
+    ok = application:set_env(wasm, compile_budget_words, Words),
+    try F()
+    after
+        case Was of
+            undefined -> application:unset_env(wasm, compile_budget_words);
+            {ok, Old} -> application:set_env(wasm, compile_budget_words, Old)
+        end
+    end.
 
 min_heap_words() ->
     {min_heap_size, Min} = erlang:system_info(min_heap_size),


### PR DESCRIPTION
`?MAX_COMPILE_FUNS` bounds one request and `compile_max_heap_words` bounds one
compiler. The slot pool allows sixteen of them, so neither says what may be
compiling at once, which `src/wasm_jit.erl` has noted all along: "Nothing bounds
the number of compilers except the sixteen slots."

`compile_budget_words` is that bound, in IR words, which is the quantity
`split/2` already weighs shards by and the one that predicts what a compile
costs. A request that does not fit beside what is running is **refused**, so the
guest interprets and asks again at the next hot call, and
`wasm_jit:diagnostics/0` says `{limit, {compile_budget, Words}}`.

Off by default, like the ceiling.

## Three decisions, with their reasons

**Refuse, never queue.** A caller that waited would hold the unit IR it was
admitted to compile for the whole wait, which is the memory the budget exists to
bound. Refusing gives it back at once; the ask's own retry interval paces the
next attempt.

**A request larger than the whole budget is still admitted when nothing else is
out.** Otherwise a budget set below one guest's hot set refuses every compile
there is, for ever, and a configuration mistake becomes a silent permanent
outage. This bounds concurrency of large compiles, not their size; size is what
the other two ceilings are for.

**The reservation is monitored, not only wrapped in an `after`.** `admitted/9`
gives the words back however the build ends, trap included. It cannot give them
back for a compiler that is *killed*, which is the ordinary case here:
`wasm_jit_sup` kills brutally and the heap ceiling kills untrappably.

Admission sits after the IR exists and before any Core does. Later would mean a
refused request had already built the largest term in the compile; earlier would
mean guessing its size.

## Notes

Two ways the new test passed while proving nothing, both found by running it
against the parent and both recorded in `PERF.md`:

- the same module twice contends for the *slot*, not the budget, so the second
  caller answers `retry` before admission is reached and the budget does
  nothing;
- waiting on `wasm_code_slots:budget/0` makes the case fail with `undef` on any
  commit that lacks it, which is indistinguishable from the failure a present
  but broken bound would give. Guarded, it fails on the parent at
  `refused() >= 1`, which is the defect.

Bounds, lifetime, code_slots, core, worker, spec and prop suites pass; lint,
xref and dialyzer clean.