### PR TITLE
Store the upstream report, and measure the crossing an out-of-VM compile would pay

### DIFF
--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4636,3 +4636,54 @@ in different clothes.
   function, which is a failure indistinguishable from the one a present but
   broken bound would produce. Guarded, the case reaches its real assertion and
   fails on the parent at `refused() >= 1`, which is the defect.
+
+## Compiling on another node is 0.5%, and the helper needs none of our code
+
+The plan for a separate compiler OS process assumed the crossing was the
+problem: "Sending Core forms over distribution encodes a multi-GB term, which is
+worse than the compile; the viable variant sends the module bytes and the wanted
+index list." That is wrong, and it was wrong in the direction that matters.
+
+QuickJS, `full`, two unit sizes, on the box that compiled them:
+
+| unit | Core words | `term_to_binary` | `binary_to_term` | compile | crossing |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 function, 98 K IR words | 4.4 M | 0.04 s, 12.8 MB | 0.05 s | 19.27 s | **0.5%** |
+| 10 functions, 385 K IR words | 17.2 M | 0.16 s, 51.5 MB | 0.24 s | 79.11 s | **0.5%** |
+
+The ratio holds because encoding is linear in the term and compiling is worse
+than linear, so it only improves with size. A 17.2 M word Core is 138 MB in
+memory and 51.5 MB on the wire, and distribution moves 128 MB in 528 ms, so the
+whole round trip is under a second against a compile of eighty.
+
+### The helper is a bare OTP node
+
+Proved rather than assumed. A `peer` started with `-pa /tmp` and no `wasm` ebin
+at all:
+
+```
+peer start         0.16 s
+peer has wasm_core  non_existing
+remote compile     19.81 s, beam 1.9 MB      (19.27 s locally)
+md5 identical      true
+bytes identical    true
+```
+
+`wasm_core:forms/8` answers a `cerl:c_module()`, which is ordinary OTP terms;
+the wasm-specific part of generated code is atoms naming `wasm_exec` functions
+that are resolved when the artifact is *loaded*, back on the application node.
+So the helper needs `compile` and nothing else, and the artifact comes back byte
+identical.
+
+Three of the four costs the plan listed for this path therefore do not exist: no
+compact versioned request format, no `wasm_core` on the helper, and no
+erlang_wasm `?ABI` to keep in step. What remains is an OTP version match, since
+the Core representation is explicitly undocumented and free to change between
+releases, and the operational cost of a second VM.
+
+**This is not an argument for building it.** It is an argument that if the
+requirement ever becomes "an adversarial compile must not take down the serving
+node", the path there is much shorter than it looked: ship the Core, get a
+`.beam` back, and put the helper in a cgroup. The bounds that shipped are
+in-VM and cannot cover allocator memory, RSS or paging, which is what actually
+happened to CPython at 33 GB.

--- a/test/audit/UPSTREAM-OTP.md
+++ b/test/audit/UPSTREAM-OTP.md
@@ -1,0 +1,91 @@
+# A report for erlang/otp, not yet filed
+
+Ready to post to `erlang/otp` as an issue. Both findings were verified against
+the installed OTP 29 (`compiler-10.0.2`) and against `compile.erl` on master,
+where `do_compile/2` is unchanged. Neither is reported upstream: the only
+related issue is #1972, the 2018 PR that introduced
+`no_spawn_compiler_process`.
+
+The numbers come from `PERF.md`, "Owning the compiler worker", and the
+reproduction in finding 2 is the probe that led to `wasm_core:reap/2`.
+
+---
+
+**Title:** compile:forms/2's worker cannot be bounded and outlives a killed caller
+
+---
+
+`compile:forms/2` runs its passes in a process it spawns itself
+(`compile.erl`, `do_compile/2`, unchanged on master):
+
+```erlang
+do_compile(Input, Opts0) ->
+    Opts = expand_opts(Opts0),
+    IntFun = internal_fun(Input, Opts),
+    case lists:member(no_spawn_compiler_process, Opts) of
+        true  -> IntFun();
+        false ->
+            {Pid,Ref} = spawn_monitor(fun() -> exit(IntFun()) end),
+            receive {'DOWN',Ref,process,Pid,Rep} -> Rep end
+    end.
+```
+
+Two consequences bite anyone compiling generated code at runtime. I hit both
+building a WebAssembly-to-BEAM tier, where guest modules are compiled on a live
+node while it serves traffic.
+
+## 1. The worker cannot be given spawn options, so its memory cannot be bounded
+
+`spawn_monitor/1` takes no options, and `max_heap_size` is not inherited, so the
+worker always runs at the system default (`+hmax`). A `max_heap_size` set on the
+calling process therefore bounds a process that only waits in `receive`.
+
+Measured on OTP 29 compiling one unit of generated Core, sampling
+`total_heap_size` at 50 ms:
+
+| process | peak |
+| --- | ---: |
+| the caller, blocked in `do_compile/2` | 141 MB |
+| the worker it is waiting on | **2,055 MB** |
+
+So the only quantity a caller can bind is 7% of the one that matters. The
+existing escape, `no_spawn_compiler_process`, moves the work onto the caller
+where its ceiling applies, but that changes the topology rather than
+configuring it.
+
+**Suggested fix**, which preserves the current topology exactly:
+
+```erlang
+{compiler_spawn_options, [spawn_option()]}
+```
+
+stripped from `Opts` before the passes run, with `spawn_monitor/1` becoming
+`spawn_opt/2`. `max_heap_size` is the option I need; `priority`,
+`fullsweep_after` and `min_heap_size` are all plausible for other callers.
+Dialyzer already reaches for `no_spawn_compiler_process`
+(`dialyzer_utils.erl`), so the "I manage my own workers" case is established.
+
+## 2. The worker is not linked, so it outlives a killed caller
+
+`spawn_monitor/1` monitors and does not link. If the caller is killed, the
+worker keeps compiling to completion, holding its own copy of the forms (the fun
+closes over `Input`, so the term is copied in at spawn), with nothing able to
+observe or stop it.
+
+```erlang
+1> P = spawn(fun() -> compile:forms(BigForms, [binary,return_errors]) end).
+2> timer:sleep(400), exit(P, kill).
+%% the worker is still alive, and still alive seconds later
+```
+
+That is a leak of a core and of however much the forms weigh, per killed
+caller. It matters most for exactly the callers who need it least to matter:
+supervised compilers that are shut down with `brutal_kill`, and anything torn
+down by `application:stop/1`.
+
+A link would fix it, at the cost of propagating a compiler crash to the caller,
+which I assume is why it is a monitor. If the current lifetime is deliberate it
+would be worth a sentence in the documentation, since "terminated at the end of
+compilation" reads as a promise that it is not.
+
+I am happy to prepare a PR for either or both if the direction is agreeable.


### PR DESCRIPTION
Two records, no runtime change.

## The upstream report, unfiled

`test/audit/UPSTREAM-OTP.md` is a report for `erlang/otp` covering the two
things this runtime had to work around in `compile:forms/2`: its worker takes no
spawn options, so its memory cannot be bounded, and it is not linked, so it
outlives a killed caller. Both were verified against the installed OTP 29 and
against `compile.erl` on master, where `do_compile/2` is unchanged. Neither is
reported upstream; the only related issue is #1972, the 2018 PR that introduced
`no_spawn_compiler_process`.

Kept in the audit record so the numbers stay with the measurement that produced
them. Not filed.

## What an out-of-VM compile would actually cost

The plan for a separate compiler process assumed the crossing was the obstacle,
and designed around it by having the helper re-lower from module bytes. That
assumption was wrong:

| unit | Core words | `term_to_binary` | `binary_to_term` | compile | crossing |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 function | 4.4 M | 0.04 s, 12.8 MB | 0.05 s | 19.27 s | **0.5%** |
| 10 functions | 17.2 M | 0.16 s, 51.5 MB | 0.24 s | 79.11 s | **0.5%** |

And the helper needs none of our code. A `peer` started with no `wasm` ebin:

```
peer has wasm_core  non_existing
remote compile      19.81 s   (19.27 s locally)
bytes identical     true
```

`wasm_core:forms/8` answers ordinary OTP terms, and the wasm-specific part of
generated code is atoms resolved when the artifact is loaded, back on the
application node.

So three of the four costs that path was thought to carry do not exist: no
versioned request format, no `wasm_core` on the helper, no erlang_wasm `?ABI` to
keep in step. What remains is an OTP version match and the operational cost of a
second VM.

Recorded rather than built. It matters only if the requirement becomes "an
adversarial compile must not take down the serving node", which the in-VM bounds
cannot promise: they cover process heap, not allocator memory, RSS or paging,
and paging is what actually happened to CPython at 33 GB.