### PR TITLE
An inline segment takes an index in its own space

### DIFF
--- a/bench/paths/compileheap.erl
+++ b/bench/paths/compileheap.erl
@@ -44,6 +44,25 @@ the clean wall and nothing else.
 sampled, but a peak between two samples is invisible, and so is the memory the
 collector needs while collecting.
 
+**`node` and `rss` are sampled beside them**, `erlang:memory(total)` and `ps`,
+because the gaps are the whole point. Measured on one QuickJS function, three
+arms:
+
+    arm      runner   worker    node     rss
+    otp        47.2    477.7  1320.3  1241.4 MB
+    inline    704.2    704.2  1685.5  1474.5 MB
+    child      53.6    477.8  1389.7  1429.2 MB
+
+Two things to read off it. The `otp` runner peaks at a *tenth* of what its own
+compiler spends, which is the blind spot this harness exists to show. And even
+the worker peak is two to three times under the node, so no per-process number
+is a substitute for the node's.
+
+`erlang:memory(total)` and RSS track within about 10%, and **either can be the
+larger**: the emulator counts pages the OS has not made resident, and the OS
+counts what the emulator does not. Do not treat one as a conservative bound on
+the other; the `child` row above has RSS above `memory(total)`.
+
 **Allocated words are per process**, from that process's own collection trace,
 by `allocwords`'s estimator: reclaimed, plus ending live, minus starting live,
 over a window a forced major collection closes at each end.
@@ -81,6 +100,12 @@ mailbox. Run it on the box before the numbers here are believed.
 -define(FLAGS, [procs, garbage_collection, set_on_spawn, monotonic_timestamp]).
 
 -define(SAMPLE_MS, 50).
+
+%% Node-level peaks for the arm currently running. In the process dictionary
+%% because the sampler is a tail-recursive loop whose accumulator is already
+%% carrying the per-pid map, and threading a second one through every clause
+%% would obscure what the loop is for.
+-define(NODE_PEAK, compileheap_node_peak).
 -define(TIMEOUT, 3600000).
 
 %% The map that would ship, at a size nothing here can reach. The gate has to
@@ -262,6 +287,7 @@ run(child, Core, Bound) ->
 %% against 167. The recorded cost was never the option; it was collecting a
 %% live set this size on every pass.
 instrumented(Arm, Core, Live) ->
+    erase(?NODE_PEAK),
     Owner = self(),
     Runner = spawn(fun () ->
                        receive go -> ok end,
@@ -309,7 +335,13 @@ watch(Runner, Peaks0, Evs, Last0) ->
 maybe_sample(Last, Peaks) ->
     Now = erlang:monotonic_time(millisecond),
     case Now - Last >= ?SAMPLE_MS of
-        true -> {Now, sample(Peaks)};
+        true ->
+            {Mem, Rss} = node_now(),
+            put(?NODE_PEAK, case get(?NODE_PEAK) of
+                                undefined -> {Mem, Rss};
+                                {M0, R0} -> {max(M0, Mem), max(R0, Rss)}
+                            end),
+            {Now, sample(Peaks)};
         false -> {Last, Peaks}
     end.
 
@@ -343,6 +375,21 @@ finish(Runner, Peaks, Evs, Result, Bounded) ->
       peaks => Peaks,
       per_pid => Per,
       result => Result}.
+
+%% What the emulator and the OS say, beside what the processes say. Sampled
+%% together, because the interesting number is the gap: a per-process peak can
+%% be two orders of magnitude under the node's, which is the whole reason this
+%% harness exists.
+node_now() ->
+    {erlang:memory(total), rss_bytes()}.
+
+%% `ps` rather than anything in the emulator, because the point is to have one
+%% number the emulator did not produce.
+rss_bytes() ->
+    case string:trim(os:cmd("ps -o rss= -p " ++ os:getpid())) of
+        "" -> 0;
+        S -> try list_to_integer(S) * 1024 catch _:_ -> 0 end
+    end.
 
 drain(Acc) ->
     receive
@@ -465,14 +512,21 @@ round_(Core, Live, I, N) ->
 one(Arm, Core, Live) ->
     #{result := R} = M = instrumented(Arm, Core, Live),
     {CleanUs, CleanR} = clean(Arm, Core, Live),
+    {NodeMem, NodeRss} = case get(?NODE_PEAK) of
+                             undefined -> {0, 0};
+                             Peak -> Peak
+                         end,
     Row = M#{arm => Arm,
+             node_mem => NodeMem,
+             node_rss => NodeRss,
              clean_us => CleanUs,
              bytes => byte_size(bin_of(R)),
              md5 => md5(bin_of(R)),
              clean_md5 => md5(bin_of(CleanR))},
-    io:format("  ~-7w clean ~7.1f s  runner ~8.1f MB  worker ~8.1f MB  ~s~n",
+    io:format("  ~-7w clean ~7.1f s  runner ~7.1f  worker ~7.1f  "
+              "node ~7.1f  rss ~7.1f MB  ~s~n",
               [Arm, CleanUs / 1000000, runner_peak(Row), worker_peak(Row),
-               note_of(Row)]),
+               NodeMem / 1048576, NodeRss / 1048576, note_of(Row)]),
     Row.
 
 clean_only(Arm, Core, Live) ->

--- a/src/wasm_wat.erl
+++ b/src/wasm_wat.erl
@@ -238,8 +238,10 @@ collect_kind(<<"import">>, Args, Ctx) ->
     [_Mod, _Name, Desc] = Args,
     collect_import(Desc, ordered(Ctx));
 collect_kind(<<"func">>, Args, Ctx) -> declare_maybe(func, Args, Ctx);
-collect_kind(<<"table">>, Args, Ctx) -> declare_maybe(table, Args, Ctx);
-collect_kind(<<"memory">>, Args, Ctx) -> declare_maybe(memory, Args, Ctx);
+collect_kind(<<"table">>, Args, Ctx) ->
+    inline_segment(elem, Args, declare_maybe(table, Args, Ctx));
+collect_kind(<<"memory">>, Args, Ctx) ->
+    inline_segment(data, Args, declare_maybe(memory, Args, Ctx));
 collect_kind(<<"global">>, Args, Ctx) -> declare_maybe(global, Args, Ctx);
 collect_kind(<<"tag">>, Args, Ctx) -> declare_maybe(tag, Args, Ctx);
 collect_kind(<<"elem">>, Args, Ctx) -> declare_maybe(elem, Args, Ctx);
@@ -252,6 +254,26 @@ collect_kind(<<"start">>, _Args, Ctx) ->
     Ctx#ctx{started = true};
 collect_kind(K, _Args, _Ctx) ->
     fail(unknown_module_field, K).
+
+%% `(memory (data "..."))' and `(table funcref (elem ...))' are a definition and
+%% a *segment* in one pair of parentheses, and the segment takes an index in its
+%% own space just as a written-out one does.
+%%
+%% Declared anonymously here so that a segment written afterwards numbers after
+%% it. Without this the two passes disagree: the name context says the `$d' in
+%% `(memory (data "\AB")) (data $d "\CD")' is data segment 0, while `datas'
+%% has the inline segment there and `$d' at 1, so `memory.init $d' reaches the
+%% inline segment. That one is active and therefore already dropped, so it traps
+%% out of bounds rather than copying the wrong bytes, which is why it went
+%% unnoticed until the specification tested it.
+inline_segment(Space, Args, Ctx) ->
+    Keyword = case Space of data -> <<"data">>; elem -> <<"elem">> end,
+    case lists:any(fun ({list, _, [{keyword, _, K} | _]}) -> K =:= Keyword;
+                       (_) -> false
+                   end, Args) of
+        true -> declare(Space, undefined, Ctx);
+        false -> Ctx
+    end.
 
 %% An inline import inside a definition counts in the same space, so
 %% `(func (import "m" "n") ...)` and `(import "m" "n" (func ...))` agree.

--- a/test/audit/PERF.md
+++ b/test/audit/PERF.md
@@ -4687,3 +4687,63 @@ node", the path there is much shorter than it looked: ship the Core, get a
 `.beam` back, and put the helper in a cgroup. The bounds that shipped are
 in-VM and cannot cover allocator memory, RSS or paging, which is what actually
 happened to CPython at 33 GB.
+
+## The aggregate bound belongs in the VM, and the entry above oversold the OS
+
+The section on compiling out of process ended by saying the in-VM bounds "cover
+process heap, not allocator memory, RSS or paging". That is true as far as it
+goes and it framed the question wrongly: it implied the OS is needed to *measure*
+a compile, and it treated RSS as the quantity to bound. Neither survives
+measurement.
+
+**The compiler's memory is process memory, because it is compiling to BEAM.**
+The OTP compiler allocates ordinary terms on process heaps. It has no arena, no
+NIF and no off-heap store, so what we want to bound is already denominated in a
+quantity the VM counts per process and can attribute to an owner. HotSpot had to
+build arena accounting into C2 to get this; `process_info(P, memory)` is it.
+
+Summing over the compile team, against the node, QuickJS units, teams traced
+with `set_on_spawn` so nothing is assumed:
+
+| | 1 compile | 4 concurrent |
+| --- | ---: | ---: |
+| sum of the compile team | 511.5 MB (3 procs) | 2095.3 MB (12 procs) |
+| `erlang:memory(processes)` | 529.6 | 2248.7 |
+| `erlang:memory(binary)` | **4.5** | **5.6** |
+| `erlang:memory(total)` | 609.1 | 2328.1 |
+| OS RSS | 1061.2 | 2215.1 |
+| **team / (total - baseline)** | **101.7%** | **94.3%** |
+
+And the residual is not hiding anywhere. At the instant node process memory
+peaks, the largest process *outside* the team is **4.7 MB**, the test's own main
+process, followed by `code_server` at 0.7 MB. There is nowhere else for a
+compiler's memory to be.
+
+**RSS is the worse instrument, not the better one.** At one compile it read
+twice the team, entirely from allocator carriers the emulator retains from
+earlier work: memory no compile caused, that killing a compile does not return.
+A cap on RSS refuses compiles for somebody else's garbage. At four compiles the
+two nearly agree (94.6%), which is the coincidence, not the rule.
+
+**Sampling is free.** One aggregate sample costs 2.4 us over 3 processes,
+11.1 us over 12, 34.9 us over 48, so a 100 ms sampler is 0.01% of a core at the
+largest team the slot pool allows. Reading a process that is collecting hard is
+stable: 300 reads during continuous churn returned no `undefined` and moved
+between 0.9 and 1.7 MB, which is the quantity itself changing across
+collections. A transient under-read delays a kill; it does not cause a wrong
+one.
+
+### What this changes
+
+`compile_budget_words` admits on *predicted* cost, in IR words, which was chosen
+because it was the only quantity available before the work began. It can be
+backed by the measured one: `wasm_code_slots` already holds the reservations and
+monitors their owners, so it can sum the team on a timer and act on the real
+number. No new process, no OS dependency, and identical on every platform, which
+`memory.max` and Job Objects are not.
+
+What the VM still cannot do is stop the operating system paging once memory is
+committed, which is what actually happened to CPython at 33 GB. But that is an
+argument for refusing earlier and killing sooner, both of which the numbers
+above make possible, and not for moving the compiler out of the node to find out
+how big it is.

--- a/test/wasm_wat_SUITE.erl
+++ b/test/wasm_wat_SUITE.erl
@@ -27,6 +27,51 @@ all() ->
      the_facade_compiles_text_too,
      the_facade_answers_a_value_for_bad_text].
 
+%% `(memory (data ...))' and `(table funcref (elem ...))' declare a segment as
+%% well as a memory or a table, and that segment takes an index. A segment
+%% written afterwards must therefore number after it.
+%%
+%% The two passes disagreed: the name context counted only written-out segments,
+%% so `$d' below resolved to 0 while `datas' had the inline segment there. The
+%% failure is quiet in the worst way. The inline segment is *active*, so it is
+%% dropped once the module is instantiated, and `memory.init $d' then traps out
+%% of bounds instead of copying the wrong bytes: an error that looks like a
+%% guest fault rather than a name resolved to the wrong thing.
+%%
+%% Reproduces the defect: on the parent `init' traps and `load' answers 0xAB.
+an_inline_segment_takes_an_index_in_its_own_space(_) ->
+    Data = <<"(module\n"
+             "  (memory (data \"\\AB\"))\n"
+             "  (data $d \"\\CD\")\n"
+             "  (func (export \"init\")\n"
+             "    (memory.init $d (i32.const 0) (i32.const 0) (i32.const 1)))\n"
+             "  (func (export \"load\") (result i32)\n"
+             "    (i32.load8_u (i32.const 0))))">>,
+    {ok, DI} = seg_instance(Data),
+    ?assertEqual({ok, []}, wasm:call(DI, <<"init">>, [])),
+    ?assertEqual({ok, [16#CD]}, wasm:call(DI, <<"load">>, [])),
+    ok = wasm:destroy(DI),
+
+    %% The same for tables, which is the other half of the abbreviation.
+    Elem = <<"(module\n"
+             "  (func $f (result i32) i32.const 0xAB)\n"
+             "  (func $g (result i32) i32.const 0xCD)\n"
+             "  (table funcref (elem (ref.func $f)))\n"
+             "  (elem $e funcref (ref.func $g))\n"
+             "  (func (export \"init\")\n"
+             "    (table.init $e (i32.const 0) (i32.const 0) (i32.const 1)))\n"
+             "  (func (export \"run\") (result i32)\n"
+             "    (call_indirect (result i32) (i32.const 0))))">>,
+    {ok, EI} = seg_instance(Elem),
+    ?assertEqual({ok, []}, wasm:call(EI, <<"init">>, [])),
+    ?assertEqual({ok, [16#CD]}, wasm:call(EI, <<"run">>, [])),
+    ok = wasm:destroy(EI).
+
+seg_instance(Wat) ->
+    {ok, P} = wasm_wat:module(Wat),
+    {ok, M} = wasm_validate:module(P),
+    wasm:instantiate(M, #{}, #{}).
+
 %% Only the differential cases need `wasm-tools`, so only they skip without one.
 init_per_testcase(Case, Config)
   when Case =:= parses_what_the_decoder_parses;


### PR DESCRIPTION
`(memory (data "..."))` declares a segment as well as a memory, and the name
pass wasn't counting it, so a segment written afterwards got numbered one too
low. In `(memory (data "\AB")) (data $d "\CD")`, `$d` resolved to segment 0.

It fails quietly in the worst way. The inline segment is active, so it's dropped
at instantiation, and `memory.init $d` then traps `out of bounds memory access`
rather than copying the wrong bytes — which reads as a guest fault, not a name
resolved to the wrong thing. Had it been passive it would have silently copied
`\AB`.

This isn't fallout from anything here: upstream testsuite `34f1f40` (2026-09-09)
added a case for each of `data` and `elem`, and CI clones the suite fresh every
run, so unmodified `main` fails it too. That's also why PR #15 is red.

The fix is in the first pass, which now declares an anonymous segment for a
memory or table carrying an inline one so the index space advances. The build
pass appended in the right order all along. The regression case doesn't need the
external clone — it fails on `main` with the trap, for both `data` and `elem`.